### PR TITLE
Maintenance/mobile app improvements

### DIFF
--- a/src/TB.DanceDance.Mobile.Library/Services/Network/NetworkStatusMonitor.cs
+++ b/src/TB.DanceDance.Mobile.Library/Services/Network/NetworkStatusMonitor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Maui.Networking;
+using Serilog;
 
 namespace TB.DanceDance.Mobile.Library.Services.Network;
 
@@ -22,7 +23,7 @@ public class NetworkStatusMonitor : IDisposable
         Connectivity.ConnectivityChanged += ConnectivityOnConnectivityChanged;
     }
     
-    private void ManageBackgroundService(NetworkAccess access, IEnumerable<ConnectionProfile> connectionProfiles)
+    public static void ManageBackgroundService(NetworkAccess access, IEnumerable<ConnectionProfile> connectionProfiles)
     {
         if (access == NetworkAccess.Internet)
         {
@@ -62,6 +63,8 @@ public class NetworkStatusMonitor : IDisposable
 
     private void ReleaseUnmanagedResources()
     {
+        Log.Information("ReleaseUnmanagedResources " + nameof(NetworkStatusMonitor));
+
         Connectivity.ConnectivityChanged -= ConnectivityOnConnectivityChanged;
     }
 

--- a/src/TB.DanceDance.Mobile.Library/TB.DanceDance.Mobile.Library.csproj
+++ b/src/TB.DanceDance.Mobile.Library/TB.DanceDance.Mobile.Library.csproj
@@ -11,7 +11,7 @@
       <PackageReference Include="Duende.IdentityModel.OidcClient" Version="7.0.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
       <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0" />
-      <PackageReference Include="Microsoft.Maui.Core" Version="10.0.11" />
+      <PackageReference Include="Microsoft.Maui.Core" Version="10.0.20" />
       <PackageReference Include="Serilog" Version="4.3.0" />
     </ItemGroup>
 

--- a/src/TB.DanceDance.Mobile/MauiProgram.cs
+++ b/src/TB.DanceDance.Mobile/MauiProgram.cs
@@ -2,6 +2,7 @@
 using Duende.IdentityModel.OidcClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Microsoft.Maui.LifecycleEvents;
 using Serilog;
 using Serilog.Events;
 using System.Threading.Channels;
@@ -21,8 +22,19 @@ public static class MauiProgram
     public static MauiApp CreateMauiApp()
     {
         var builder = MauiApp.CreateBuilder();
+
+        
+
         builder
             .UseMauiApp<App>()
+            .ConfigureLifecycleEvents(events =>
+            {
+#if ANDROID
+    events.AddAndroid(android => android
+        .OnResume(e => ManageUploading())
+        .OnCreate((e,x) => ManageUploading()));
+#endif
+            })
             .UseMauiCommunityToolkitMediaElement()
             .UseMauiCommunityToolkit()
             .ConfigureFonts(fonts =>
@@ -116,5 +128,12 @@ public static class MauiProgram
 
 
         return builder.Build();
+    }
+
+    private static void ManageUploading()
+    {
+#if ANDROID
+        NetworkStatusMonitor.ManageBackgroundService(Connectivity.Current.NetworkAccess, Connectivity.Current.ConnectionProfiles);
+#endif
     }
 }

--- a/src/TB.DanceDance.Mobile/TB.DanceDance.Mobile.csproj
+++ b/src/TB.DanceDance.Mobile/TB.DanceDance.Mobile.csproj
@@ -117,7 +117,7 @@
 		<PackageReference Include="Duende.IdentityModel.OidcClient" Version="7.0.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.20" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
 		<PackageReference Include="Serilog" Version="4.3.0" />
 		<PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />

--- a/src/TB.DanceDance.Mobile/TB.DanceDance.Mobile.csproj
+++ b/src/TB.DanceDance.Mobile/TB.DanceDance.Mobile.csproj
@@ -45,38 +45,38 @@
 	  <AndroidPackageFormat>aab</AndroidPackageFormat>
 	  <AndroidUseAapt2>True</AndroidUseAapt2>
 	  <AndroidCreatePackagePerAbi>False</AndroidCreatePackagePerAbi>
-	  <ApplicationVersion>16</ApplicationVersion>
+	  <ApplicationVersion>17</ApplicationVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-android|AnyCPU'">
 	  <AndroidPackageFormat>aab</AndroidPackageFormat>
 	  <AndroidUseAapt2>True</AndroidUseAapt2>
 	  <AndroidCreatePackagePerAbi>False</AndroidCreatePackagePerAbi>
-	  <ApplicationVersion>16</ApplicationVersion>
+	  <ApplicationVersion>17</ApplicationVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-ios|AnyCPU'">
-	  <ApplicationVersion>16</ApplicationVersion>
+	  <ApplicationVersion>17</ApplicationVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-maccatalyst|AnyCPU'">
-	  <ApplicationVersion>16</ApplicationVersion>
+	  <ApplicationVersion>17</ApplicationVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-windows10.0.19041.0|AnyCPU'">
-	  <ApplicationVersion>16</ApplicationVersion>
+	  <ApplicationVersion>17</ApplicationVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-ios|AnyCPU'">
-	  <ApplicationVersion>16</ApplicationVersion>
+	  <ApplicationVersion>17</ApplicationVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-maccatalyst|AnyCPU'">
-	  <ApplicationVersion>16</ApplicationVersion>
+	  <ApplicationVersion>17</ApplicationVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-windows10.0.19041.0|AnyCPU'">
-	  <ApplicationVersion>16</ApplicationVersion>
+	  <ApplicationVersion>17</ApplicationVersion>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary
Fixes crash on app navigation/close related to service provider disposal on Android by registering network connectivity actions on `OnResume` and `OnCreate` lifecycle events. Also updates MAUI packages to version 10.0.20.

## Problem
Addresses [[dotnet/maui#32750](https://github.com/dotnet/maui/issues/32750)] where the Android app crashes with `ObjectDisposedException` when navigating back or closing the app due to IServiceProvider being disposed prematurely.

## Changes
- **Lifecycle event handling**: Added `OnResume` and `OnCreate` event handlers in `MauiProgram.cs` to manage background upload service based on network connectivity
- **NetworkStatusMonitor refactoring**: Made `ManageBackgroundService` method public and static to allow external calls from lifecycle events
- **Package updates**: Updated Microsoft.Maui packages from 10.0.11 to 10.0.20
- **Version bump**: Incremented application version to 17
- **Logging**: Added logging for `NetworkStatusMonitor` disposal

## Test Plan
- [x] Test app launch on Android
- [x] Test app backgrounding and foregrounding
- [x] Test back navigation
- [x] Verify network connectivity changes are handled correctly
- [x] Confirm no ObjectDisposedException crashes occur
