### PR TITLE
Move Comments feature to vertical-slice folders

### DIFF
--- a/src/backend/Application/DependencyInjection.cs
+++ b/src/backend/Application/DependencyInjection.cs
@@ -1,4 +1,5 @@
-﻿using Application.Services;
+﻿using Application.Features.Comments;
+using Application.Services;
 using Domain.Services;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -17,8 +18,9 @@ public static class DependencyInjection
                 .AddScoped<IEventService, EventService>()
                 .AddScoped<IGroupService, GroupService>()
                 .AddScoped<IVideoUploaderService, VideoUploaderService>()
-                .AddScoped<ISharedLinkService, SharedLinkService>()
-                .AddScoped<ICommentService, CommentService>();
+                .AddScoped<ISharedLinkService, SharedLinkService>();
+
+            services.AddCommentsFeature();
 
             return services;
         }

--- a/src/backend/Application/Features/Comments/CommentService.cs
+++ b/src/backend/Application/Features/Comments/CommentService.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 using System.Security.Cryptography;
 using System.Text;
 
-namespace Application.Services;
+namespace Application.Features.Comments;
 
 public class CommentService : ICommentService
 {

--- a/src/backend/Application/Features/Comments/CommentsModule.cs
+++ b/src/backend/Application/Features/Comments/CommentsModule.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Application.Features.Comments;
+
+public static class CommentsModule
+{
+    extension(IServiceCollection services)
+    {
+        public IServiceCollection AddCommentsFeature()
+        {
+            services.AddScoped<ICommentService, CommentService>();
+            return services;
+        }
+    }
+}

--- a/src/backend/Application/Features/Comments/ICommentService.cs
+++ b/src/backend/Application/Features/Comments/ICommentService.cs
@@ -1,6 +1,6 @@
 using Domain.Entities;
 
-namespace Domain.Services;
+namespace Application.Features.Comments;
 
 public interface ICommentService
 {

--- a/src/backend/TB.DanceDance.API.Contracts/Features/Comments/CommentResponse.cs
+++ b/src/backend/TB.DanceDance.API.Contracts/Features/Comments/CommentResponse.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace TB.DanceDance.API.Contracts.Responses
+namespace TB.DanceDance.API.Contracts.Features.Comments
 {
     public class CommentResponse
     {

--- a/src/backend/TB.DanceDance.API.Contracts/Features/Comments/Comments.cs
+++ b/src/backend/TB.DanceDance.API.Contracts/Features/Comments/Comments.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace TB.DanceDance.API.Contracts.Requests
+namespace TB.DanceDance.API.Contracts.Features.Comments
 {
     public abstract class BaseComment
     {

--- a/src/backend/TB.DanceDance.API/ApiEndpoints.cs
+++ b/src/backend/TB.DanceDance.API/ApiEndpoints.cs
@@ -66,20 +66,6 @@ public static class ApiEndpoints
         public const string GetStream = $"{Base}/{{linkId}}/stream";
     }
 
-    public static class Comments
-    {
-        private const string Base = $"{ApiBase}/comments";
-
-        public const string GetCommentsForVideo = $"{Base}/video/{{videoId:guid}}";
-        public const string Create = $"{ApiBase}/share/{{linkId}}/comments";
-        public const string GetByLink = $"{ApiBase}/share/{{linkId}}/comments";
-        public const string Update = $"{Base}/{{commentId:guid}}";
-        public const string Delete = $"{Base}/{{commentId:guid}}";
-        public const string Hide = $"{Base}/{{commentId:guid}}/hide";
-        public const string Unhide = $"{Base}/{{commentId:guid}}/unhide";
-        public const string Report = $"{Base}/{{commentId:guid}}/report";
-    }
-
     public static class Info
     {
         public const string AllEndpoints = "/.endpoints";

--- a/src/backend/TB.DanceDance.API/Features/Comments/CommentRoutes.cs
+++ b/src/backend/TB.DanceDance.API/Features/Comments/CommentRoutes.cs
@@ -1,0 +1,16 @@
+namespace TB.DanceDance.API.Features.Comments;
+
+public static class CommentRoutes
+{
+    private const string ApiBase = "api";
+    private const string Base = $"{ApiBase}/comments";
+
+    public const string GetCommentsForVideo = $"{Base}/video/{{videoId:guid}}";
+    public const string Create = $"{ApiBase}/share/{{linkId}}/comments";
+    public const string GetByLink = $"{ApiBase}/share/{{linkId}}/comments";
+    public const string Update = $"{Base}/{{commentId:guid}}";
+    public const string Delete = $"{Base}/{{commentId:guid}}";
+    public const string Hide = $"{Base}/{{commentId:guid}}/hide";
+    public const string Unhide = $"{Base}/{{commentId:guid}}/unhide";
+    public const string Report = $"{Base}/{{commentId:guid}}/report";
+}

--- a/src/backend/TB.DanceDance.API/Features/Comments/CommentsController.cs
+++ b/src/backend/TB.DanceDance.API/Features/Comments/CommentsController.cs
@@ -1,15 +1,14 @@
+using Application.Features.Comments;
 using Domain.Entities;
-using Domain.Services;
 using Infrastructure.Identity.IdentityResources;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Security.Cryptography;
 using System.Text;
-using TB.DanceDance.API.Contracts.Requests;
-using TB.DanceDance.API.Contracts.Responses;
+using TB.DanceDance.API.Contracts.Features.Comments;
 using TB.DanceDance.API.Extensions;
 
-namespace TB.DanceDance.API.Controllers;
+namespace TB.DanceDance.API.Features.Comments;
 
 [Authorize(DanceDanceResources.WestCoastSwing.Scopes.ReadScope)]
 public class CommentsController : Controller
@@ -29,7 +28,7 @@ public class CommentsController : Controller
     /// </summary>
     [AllowAnonymous]
     [HttpPost]
-    [Route(ApiEndpoints.Comments.Create)]
+    [Route(CommentRoutes.Create)]
     public async Task<ActionResult<CommentResponse>> CreateComment(
         [FromRoute] string linkId,
         [FromBody] CreateCommentRequest request,
@@ -65,7 +64,7 @@ public class CommentsController : Controller
     /// </summary>
     [AllowAnonymous]
     [HttpGet]
-    [Route(ApiEndpoints.Comments.GetByLink)]
+    [Route(CommentRoutes.GetByLink)]
     public async Task<ActionResult<IEnumerable<CommentResponse>>> GetCommentsByLink(
         [FromRoute] string linkId,
         [FromQuery] string? anonymousId,
@@ -99,7 +98,7 @@ public class CommentsController : Controller
     /// </summary>
     [HttpPut]
     [AllowAnonymous]
-    [Route(ApiEndpoints.Comments.Update)]
+    [Route(CommentRoutes.Update)]
     public async Task<IActionResult> UpdateComment(
         [FromRoute] Guid commentId,
         [FromBody] UpdateCommentRequest request,
@@ -146,7 +145,7 @@ public class CommentsController : Controller
     /// Deletes a comment. Can be deleted by the author or video owner.
     /// </summary>
     [AllowAnonymous]
-    [Route(ApiEndpoints.Comments.Delete)]
+    [Route(CommentRoutes.Delete)]
     [HttpDelete]
     public async Task<IActionResult> DeleteComment(
         [FromRoute] Guid commentId,
@@ -181,7 +180,7 @@ public class CommentsController : Controller
     /// Hides a comment. Only the video owner can hide comments.
     /// </summary>
     [HttpPut]
-    [Route(ApiEndpoints.Comments.Hide)]
+    [Route(CommentRoutes.Hide)]
     public async Task<IActionResult> HideComment(
         [FromRoute] Guid commentId,
         CancellationToken cancellationToken)
@@ -202,7 +201,7 @@ public class CommentsController : Controller
     /// Unhides a comment. Only the video owner can unhide comments.
     /// </summary>
     [HttpPut]
-    [Route(ApiEndpoints.Comments.Unhide)]
+    [Route(CommentRoutes.Unhide)]
     public async Task<IActionResult> UnhideComment(
         [FromRoute] Guid commentId,
         CancellationToken cancellationToken)
@@ -224,7 +223,7 @@ public class CommentsController : Controller
     /// </summary>
     [AllowAnonymous]
     [HttpPost]
-    [Route(ApiEndpoints.Comments.Report)]
+    [Route(CommentRoutes.Report)]
     public async Task<IActionResult> ReportComment(
         [FromRoute] Guid commentId,
         [FromBody] ReportCommentRequest request,
@@ -249,7 +248,7 @@ public class CommentsController : Controller
     }
     
     [HttpGet]
-    [Route(ApiEndpoints.Comments.GetCommentsForVideo)]
+    [Route(CommentRoutes.GetCommentsForVideo)]
     public async Task<IActionResult> GetCommentsForVideo([FromRoute] Guid videoId, CancellationToken cancellationToken)
     {
         var userId = User.GetSubject();

--- a/src/tests/TB.DanceDance.Tests/Features/Comments/CommentServiceTests.cs
+++ b/src/tests/TB.DanceDance.Tests/Features/Comments/CommentServiceTests.cs
@@ -1,10 +1,9 @@
-using Application.Services;
+using Application.Features.Comments;
 using Domain.Entities;
-using Domain.Services;
 using Infrastructure.Data;
 using TB.DanceDance.Tests.TestsFixture;
 
-namespace TB.DanceDance.Tests.Application;
+namespace TB.DanceDance.Tests.Features.Comments;
 
 public class CommentServiceTests : BaseTestClass
 {


### PR DESCRIPTION
## Summary
- Pilots the vertical-slice folder convention with the Comments slice (8 endpoints — get-for-video, create-by-link, get-by-link, update, delete, hide, unhide, report).
- Controller, service, interface, DTOs, route constants, and tests now live under `Features/Comments/` in their respective projects.
- `ICommentService` moves out of `Domain.Services` into `Application.Features.Comments` — the interface is the feature's contract, not a domain abstraction.
- `CommentRoutes` extracted from `ApiEndpoints.cs`; DI registration moved into a per-feature `AddCommentsFeature()` extension in `CommentsModule.cs` (C# 14 `extension(IServiceCollection)` block syntax).
- Entities (`Comment`, `CommentVisibility`) stay in `Domain/Entities/` per the locked plan.
- Mobile project unaffected — verified zero references to Comments DTOs in `src/mobile/`.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test --filter "FullyQualifiedName~Comment"` — 54/54 pass
- [ ] Local stack smoke test via React frontend on a shared video link (post anon comment, edit, delete, hide as owner, unhide, report)
- [ ] CI (`pr-gated.yaml`) green