### PR TITLE
Move Sharing feature to vertical-slice folders

### DIFF
--- a/src/backend/Application/DependencyInjection.cs
+++ b/src/backend/Application/DependencyInjection.cs
@@ -1,4 +1,5 @@
-﻿using Application.Services;
+﻿using Application.Features.Sharing;
+using Application.Services;
 using Domain.Services;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -17,8 +18,9 @@ public static class DependencyInjection
                 .AddScoped<IEventService, EventService>()
                 .AddScoped<IGroupService, GroupService>()
                 .AddScoped<IVideoUploaderService, VideoUploaderService>()
-                .AddScoped<ISharedLinkService, SharedLinkService>()
                 .AddScoped<ICommentService, CommentService>();
+
+            services.AddSharingFeature();
 
             return services;
         }

--- a/src/backend/Application/Features/Sharing/ISharedLinkService.cs
+++ b/src/backend/Application/Features/Sharing/ISharedLinkService.cs
@@ -1,6 +1,6 @@
 using Domain.Entities;
 
-namespace Domain.Services;
+namespace Application.Features.Sharing;
 
 public interface ISharedLinkService
 {

--- a/src/backend/Application/Features/Sharing/SharedLinkService.cs
+++ b/src/backend/Application/Features/Sharing/SharedLinkService.cs
@@ -2,7 +2,7 @@ using Domain.Entities;
 using Domain.Services;
 using Microsoft.EntityFrameworkCore;
 
-namespace Application.Services;
+namespace Application.Features.Sharing;
 
 public class SharedLinkService : ISharedLinkService
 {

--- a/src/backend/Application/Features/Sharing/SharingModule.cs
+++ b/src/backend/Application/Features/Sharing/SharingModule.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Application.Features.Sharing;
+
+public static class SharingModule
+{
+    extension(IServiceCollection services)
+    {
+        public IServiceCollection AddSharingFeature()
+        {
+            services.AddScoped<ISharedLinkService, SharedLinkService>();
+            return services;
+        }
+    }
+}

--- a/src/backend/TB.DanceDance.API.Contracts/Features/Sharing/CreateSharedLinkRequest.cs
+++ b/src/backend/TB.DanceDance.API.Contracts/Features/Sharing/CreateSharedLinkRequest.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 
-namespace TB.DanceDance.API.Contracts.Requests
+namespace TB.DanceDance.API.Contracts.Features.Sharing
 {
     public class CreateSharedLinkRequest
     {

--- a/src/backend/TB.DanceDance.API.Contracts/Features/Sharing/SharedLinkResponse.cs
+++ b/src/backend/TB.DanceDance.API.Contracts/Features/Sharing/SharedLinkResponse.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace TB.DanceDance.API.Contracts.Responses
+namespace TB.DanceDance.API.Contracts.Features.Sharing
 {
     public class SharedLinkResponse
     {

--- a/src/backend/TB.DanceDance.API.Contracts/Features/Sharing/SharedVideoInfoResponse.cs
+++ b/src/backend/TB.DanceDance.API.Contracts/Features/Sharing/SharedVideoInfoResponse.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace TB.DanceDance.API.Contracts.Responses
+namespace TB.DanceDance.API.Contracts.Features.Sharing
 {
     public class SharedVideoInfoResponse
     {

--- a/src/backend/TB.DanceDance.API/ApiEndpoints.cs
+++ b/src/backend/TB.DanceDance.API/ApiEndpoints.cs
@@ -55,17 +55,6 @@ public static class ApiEndpoints
         public const string GetPublishSas = $"{Base}/videos/{{videoId}}/sas";
     }
 
-    public static class Share
-    {
-        private const string Base = $"{ApiBase}/share";
-
-        public const string Create = $"{ApiBase}/videos/{{videoId:guid}}/share";
-        public const string Revoke = $"{Base}/{{linkId}}";
-        public const string GetMy = $"{Base}/my";
-        public const string GetInfo = $"{Base}/{{linkId}}";
-        public const string GetStream = $"{Base}/{{linkId}}/stream";
-    }
-
     public static class Comments
     {
         private const string Base = $"{ApiBase}/comments";

--- a/src/backend/TB.DanceDance.API/Features/Sharing/ShareController.cs
+++ b/src/backend/TB.DanceDance.API/Features/Sharing/ShareController.cs
@@ -1,13 +1,13 @@
+using Application.Features.Sharing;
 using Domain.Services;
 using Infrastructure.Identity.IdentityResources;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
-using TB.DanceDance.API.Contracts.Requests;
-using TB.DanceDance.API.Contracts.Responses;
+using TB.DanceDance.API.Contracts.Features.Sharing;
 using TB.DanceDance.API.Extensions;
 
-namespace TB.DanceDance.API.Controllers;
+namespace TB.DanceDance.API.Features.Sharing;
 
 [Authorize(DanceDanceResources.WestCoastSwing.Scopes.ReadScope)]
 public class ShareController : Controller
@@ -33,7 +33,7 @@ public class ShareController : Controller
     /// Creates a shared link for a video. Requires authentication.
     /// </summary>
     [HttpPost]
-    [Route(ApiEndpoints.Share.Create)]
+    [Route(ShareRoutes.Create)]
     public async Task<ActionResult<SharedLinkResponse>> CreateSharedLink(
         [FromRoute] Guid videoId,
         [FromBody] CreateSharedLinkRequest request,
@@ -77,7 +77,7 @@ public class ShareController : Controller
     /// Revokes a shared link. Requires authentication. Only the link creator or video owner can revoke.
     /// </summary>
     [HttpDelete]
-    [Route(ApiEndpoints.Share.Revoke)]
+    [Route(ShareRoutes.Revoke)]
     public async Task<IActionResult> RevokeSharedLink(
         [FromRoute] string linkId,
         CancellationToken cancellationToken)
@@ -98,7 +98,7 @@ public class ShareController : Controller
     /// Gets all shared links created by the user or for videos owned by the user. Requires authentication.
     /// </summary>
     [HttpGet]
-    [Route(ApiEndpoints.Share.GetMy)]
+    [Route(ShareRoutes.GetMy)]
     public async Task<ActionResult<IEnumerable<SharedLinkResponse>>> GetMySharedLinks(CancellationToken cancellationToken)
     {
         var userId = User.GetSubject();
@@ -128,7 +128,7 @@ public class ShareController : Controller
     /// </summary>
     [AllowAnonymous]
     [HttpGet]
-    [Route(ApiEndpoints.Share.GetInfo)]
+    [Route(ShareRoutes.GetInfo)]
     public async Task<ActionResult<SharedVideoInfoResponse>> GetVideoInfoBySharedLink(
         [FromRoute] string linkId,
         CancellationToken cancellationToken)
@@ -167,7 +167,7 @@ public class ShareController : Controller
     /// </summary>
     [AllowAnonymous]
     [HttpGet]
-    [Route(ApiEndpoints.Share.GetStream)]
+    [Route(ShareRoutes.GetStream)]
     public async Task<IActionResult> StreamVideoBySharedLink(
         [FromRoute] string linkId,
         CancellationToken cancellationToken)

--- a/src/backend/TB.DanceDance.API/Features/Sharing/ShareRoutes.cs
+++ b/src/backend/TB.DanceDance.API/Features/Sharing/ShareRoutes.cs
@@ -1,0 +1,13 @@
+namespace TB.DanceDance.API.Features.Sharing;
+
+public static class ShareRoutes
+{
+    private const string ApiBase = "api";
+    private const string Base = $"{ApiBase}/share";
+
+    public const string Create = $"{ApiBase}/videos/{{videoId:guid}}/share";
+    public const string Revoke = $"{Base}/{{linkId}}";
+    public const string GetMy = $"{Base}/my";
+    public const string GetInfo = $"{Base}/{{linkId}}";
+    public const string GetStream = $"{Base}/{{linkId}}/stream";
+}

--- a/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/DanceHttpApiClient.cs
+++ b/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/DanceHttpApiClient.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System.Net.Http.Json;
+using TB.DanceDance.API.Contracts.Features.Sharing;
 using TB.DanceDance.API.Contracts.Models;
 using TB.DanceDance.API.Contracts.Requests;
 using TB.DanceDance.API.Contracts.Responses;

--- a/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/IDanceHttpApiClient.cs
+++ b/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/IDanceHttpApiClient.cs
@@ -1,4 +1,5 @@
-﻿using TB.DanceDance.API.Contracts.Models;
+﻿using TB.DanceDance.API.Contracts.Features.Sharing;
+using TB.DanceDance.API.Contracts.Models;
 using TB.DanceDance.API.Contracts.Requests;
 using TB.DanceDance.API.Contracts.Responses;
 

--- a/src/mobile/TB.DanceDance.Mobile/Pages/Popups/SharingPopupViewModel.cs
+++ b/src/mobile/TB.DanceDance.Mobile/Pages/Popups/SharingPopupViewModel.cs
@@ -2,6 +2,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
+using TB.DanceDance.API.Contracts.Features.Sharing;
 using TB.DanceDance.API.Contracts.Responses;
 using TB.DanceDance.Mobile.Library.Services.DanceApi;
 namespace TB.DanceDance.Mobile.Pages.Popups;

--- a/src/tests/TB.DanceDance.Mobile.Tests/IntegrationTests/DanceHttpApiClientTests.cs
+++ b/src/tests/TB.DanceDance.Mobile.Tests/IntegrationTests/DanceHttpApiClientTests.cs
@@ -1,5 +1,6 @@
 ﻿using NSubstitute;
 using System.Text.Json;
+using TB.DanceDance.API.Contracts.Features.Sharing;
 using TB.DanceDance.API.Contracts.Models;
 using TB.DanceDance.API.Contracts.Requests;
 using TB.DanceDance.API.Contracts.Responses;

--- a/src/tests/TB.DanceDance.Tests/Features/Sharing/SharedLinkServiceTests.cs
+++ b/src/tests/TB.DanceDance.Tests/Features/Sharing/SharedLinkServiceTests.cs
@@ -1,10 +1,11 @@
+using Application.Features.Sharing;
 using Application.Services;
 using Domain.Entities;
 using Domain.Services;
 using Infrastructure.Data;
 using TB.DanceDance.Tests.TestsFixture;
 
-namespace TB.DanceDance.Tests.Application;
+namespace TB.DanceDance.Tests.Features.Sharing;
 
 public class SharedLinkServiceTests : BaseTestClass
 {


### PR DESCRIPTION
## Summary
- Continues the vertical-slice pilot with the Sharing slice (5 endpoints — create, revoke, list-mine, get-info-by-link, stream-by-link).
- Controller, service, interface, DTOs, route constants, and tests now live under `Features/Sharing/` in their respective projects.
- `ISharedLinkService` moves out of `Domain.Services` into `Application.Features.Sharing`.
- `ShareRoutes` extracted from `ApiEndpoints.cs`; DI registration moved into a per-feature `AddSharingFeature()` extension in `SharingModule.cs`.
- Mobile (Library, MAUI app, test project) gains a `using TB.DanceDance.API.Contracts.Features.Sharing;` alongside the existing Contracts namespaces — 4 files touched.
- Note: `SharedVideoInformationRequest` (uses `SharingWithType`) stays put — belongs to the video-upload feature, not Sharing.

## Test plan
- [x] `dotnet build` (backend + mobile + tests) — 0 errors
- [x] `dotnet test --filter "FullyQualifiedName~SharedLink"` — 27/27 pass
- [x] `dotnet build ./src/mobile/TB.DanceDance.Mobile/ -c Release -f net10.0-android` — 0 errors
- [ ] Local stack smoke test (create shared link, open as anon, revoke)
- [ ] CI (`pr-gated.yaml`) green

> Depends on #71 stylistically (same convention) but contains no overlapping files — can merge independently.