### PR TITLE
Move Groups feature to vertical-slice folders

### DIFF
--- a/src/backend/Application/DependencyInjection.cs
+++ b/src/backend/Application/DependencyInjection.cs
@@ -1,4 +1,5 @@
-﻿using Application.Services;
+﻿using Application.Features.Groups;
+using Application.Services;
 using Domain.Services;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -15,10 +16,11 @@ public static class DependencyInjection
                 .AddScoped<IAccessService, AccessService>()
                 .AddScoped<IVideoService, VideoService>()
                 .AddScoped<IEventService, EventService>()
-                .AddScoped<IGroupService, GroupService>()
                 .AddScoped<IVideoUploaderService, VideoUploaderService>()
                 .AddScoped<ISharedLinkService, SharedLinkService>()
                 .AddScoped<ICommentService, CommentService>();
+
+            services.AddGroupsFeature();
 
             return services;
         }

--- a/src/backend/Application/Features/Groups/GroupService.cs
+++ b/src/backend/Application/Features/Groups/GroupService.cs
@@ -1,8 +1,7 @@
 ﻿using Domain.Entities;
-using Domain.Services;
 using Microsoft.EntityFrameworkCore;
 
-namespace Application.Services;
+namespace Application.Features.Groups;
 
 public class GroupService : IGroupService
 {

--- a/src/backend/Application/Features/Groups/GroupsModule.cs
+++ b/src/backend/Application/Features/Groups/GroupsModule.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Application.Features.Groups;
+
+public static class GroupsModule
+{
+    extension(IServiceCollection services)
+    {
+        public IServiceCollection AddGroupsFeature()
+        {
+            services.AddScoped<IGroupService, GroupService>();
+            return services;
+        }
+    }
+}

--- a/src/backend/Application/Features/Groups/IGroupService.cs
+++ b/src/backend/Application/Features/Groups/IGroupService.cs
@@ -1,6 +1,6 @@
 ﻿using Domain.Entities;
 
-namespace Domain.Services;
+namespace Application.Features.Groups;
 public interface IGroupService
 {
     Task<ICollection<Group>> GetAllGroups(CancellationToken cancellationToken);

--- a/src/backend/TB.DanceDance.API.Contracts/Features/Groups/GroupWithVideosResponse.cs
+++ b/src/backend/TB.DanceDance.API.Contracts/Features/Groups/GroupWithVideosResponse.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using TB.DanceDance.API.Contracts.Responses;
+
+namespace TB.DanceDance.API.Contracts.Features.Groups
+{
+    public class GroupWithVideosResponse
+    {
+        public Guid GroupId { get; set; }
+        public string GroupName { get; set; } = null!;
+        public DateTime SeasonStart { get; set; }
+        public DateTime SeasonEnd { get; set; }
+        public ICollection<VideoInformationModel> Videos { get; set; } = null!;
+    }
+}

--- a/src/backend/TB.DanceDance.API.Contracts/Responses/VideoInformationResponse.cs
+++ b/src/backend/TB.DanceDance.API.Contracts/Responses/VideoInformationResponse.cs
@@ -1,20 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+using System;
 
 namespace TB.DanceDance.API.Contracts.Responses
 {
     public class VideoInformationResponse : VideoInformationModel
     {
 
-    }
-
-    public class GroupWithVideosResponse
-    {
-        public Guid GroupId { get; set; }
-        public string GroupName { get; set; } = null!;
-        public DateTime SeasonStart { get; set; }
-        public DateTime SeasonEnd { get; set; }
-        public ICollection<VideoInformationModel> Videos { get; set; } = null!;
     }
 
     public class VideoInformationModel

--- a/src/backend/TB.DanceDance.API/ApiEndpoints.cs
+++ b/src/backend/TB.DanceDance.API/ApiEndpoints.cs
@@ -30,14 +30,6 @@ public static class ApiEndpoints
 
     }
 
-    public static class Group
-    {
-        private const string Base = $"{ApiBase}/groups";
-
-        public const string Videos = $"{Base}/videos";
-        public const string VideosForGroup = $"{Base}/{{groupId:guid}}/videos";
-    }
-
     public static class Event
     {
         private const string Base = $"{ApiBase}/events";

--- a/src/backend/TB.DanceDance.API/Controllers/EventsController.cs
+++ b/src/backend/TB.DanceDance.API/Controllers/EventsController.cs
@@ -1,4 +1,5 @@
-﻿using Domain.Exceptions;
+﻿using Application.Features.Groups;
+using Domain.Exceptions;
 using Domain.Services;
 using Infrastructure.Identity.IdentityResources;
 using Microsoft.AspNetCore.Authorization;

--- a/src/backend/TB.DanceDance.API/Features/Groups/GroupController.cs
+++ b/src/backend/TB.DanceDance.API/Features/Groups/GroupController.cs
@@ -1,13 +1,14 @@
-﻿using Domain.Entities;
-using Domain.Services;
+﻿using Application.Features.Groups;
+using Domain.Entities;
 using Infrastructure.Identity.IdentityResources;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using TB.DanceDance.API.Contracts.Features.Groups;
 using TB.DanceDance.API.Contracts.Responses;
 using TB.DanceDance.API.Extensions;
 using TB.DanceDance.API.Mappers;
 
-namespace TB.DanceDance.API.Controllers;
+namespace TB.DanceDance.API.Features.Groups;
 
 [Authorize(DanceDanceResources.WestCoastSwing.Scopes.ReadScope)]
 public class GroupController : Controller
@@ -20,7 +21,7 @@ public class GroupController : Controller
     }
 
     [HttpGet]
-    [Route(ApiEndpoints.Group.Videos)]
+    [Route(GroupRoutes.Videos)]
     public async Task<IActionResult> GetVideosAsync(CancellationToken cancellationToken)
     {
         var userId = User.GetSubject();
@@ -34,7 +35,7 @@ public class GroupController : Controller
     }
 
     [HttpGet]
-    [Route(ApiEndpoints.Group.VideosForGroup)]
+    [Route(GroupRoutes.VideosForGroup)]
     public async Task<IActionResult> GetVideosPerGroup(Guid groupId, CancellationToken cancellationToken)
     {
         var userId = User.GetSubject();

--- a/src/backend/TB.DanceDance.API/Features/Groups/GroupRoutes.cs
+++ b/src/backend/TB.DanceDance.API/Features/Groups/GroupRoutes.cs
@@ -1,0 +1,10 @@
+namespace TB.DanceDance.API.Features.Groups;
+
+public static class GroupRoutes
+{
+    private const string ApiBase = "api";
+    private const string Base = $"{ApiBase}/groups";
+
+    public const string Videos = $"{Base}/videos";
+    public const string VideosForGroup = $"{Base}/{{groupId:guid}}/videos";
+}

--- a/src/mobile/TB.DanceDance.Mobile.Library/Data/Models/Video.cs
+++ b/src/mobile/TB.DanceDance.Mobile.Library/Data/Models/Video.cs
@@ -1,4 +1,5 @@
-﻿using TB.DanceDance.API.Contracts.Responses;
+﻿using TB.DanceDance.API.Contracts.Features.Groups;
+using TB.DanceDance.API.Contracts.Responses;
 
 namespace TB.DanceDance.Mobile.Library.Data.Models;
 

--- a/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/DanceHttpApiClient.cs
+++ b/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/DanceHttpApiClient.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System.Net.Http.Json;
+using TB.DanceDance.API.Contracts.Features.Groups;
 using TB.DanceDance.API.Contracts.Models;
 using TB.DanceDance.API.Contracts.Requests;
 using TB.DanceDance.API.Contracts.Responses;

--- a/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/IDanceHttpApiClient.cs
+++ b/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/IDanceHttpApiClient.cs
@@ -1,4 +1,5 @@
-﻿using TB.DanceDance.API.Contracts.Models;
+﻿using TB.DanceDance.API.Contracts.Features.Groups;
+using TB.DanceDance.API.Contracts.Models;
 using TB.DanceDance.API.Contracts.Requests;
 using TB.DanceDance.API.Contracts.Responses;
 

--- a/src/tests/TB.DanceDance.Mobile.Tests/IntegrationTests/DanceHttpApiClientTests.cs
+++ b/src/tests/TB.DanceDance.Mobile.Tests/IntegrationTests/DanceHttpApiClientTests.cs
@@ -1,5 +1,6 @@
 ﻿using NSubstitute;
 using System.Text.Json;
+using TB.DanceDance.API.Contracts.Features.Groups;
 using TB.DanceDance.API.Contracts.Models;
 using TB.DanceDance.API.Contracts.Requests;
 using TB.DanceDance.API.Contracts.Responses;

--- a/src/tests/TB.DanceDance.Tests/Features/Groups/GroupServiceTests.cs
+++ b/src/tests/TB.DanceDance.Tests/Features/Groups/GroupServiceTests.cs
@@ -1,9 +1,9 @@
-﻿using Application.Services;
+﻿using Application.Features.Groups;
 using Domain.Entities;
 using Infrastructure.Data;
 using TB.DanceDance.Tests.TestsFixture;
 
-namespace TB.DanceDance.Tests.Application;
+namespace TB.DanceDance.Tests.Features.Groups;
 
 public class GroupServiceTests : BaseTestClass
 {


### PR DESCRIPTION
## Summary
- Continues the vertical-slice pilot with the Groups slice (2 endpoints — list videos across all groups the user belongs to, list videos for a single group).
- Controller, service, interface, DTOs, route constants, and tests now live under `Features/Groups/` in their respective projects.
- `IGroupService` moves out of `Domain.Services` into `Application.Features.Groups`.
- `GroupRoutes` extracted from `ApiEndpoints.cs`; DI registration moved into a per-feature `AddGroupsFeature()` extension in `GroupsModule.cs`.
- Contracts split: `GroupWithVideosResponse` moves into `Contracts/Features/Groups/`, while `VideoInformationResponse` + `VideoInformationModel` (used across the Videos/Events slices) stay in `Contracts/Responses/VideoInformationResponse.cs` until those slices migrate.
- `EventsController` gains a `using Application.Features.Groups;` since it still consumes `IGroupService`.
- Mobile (Library `IDanceHttpApiClient`/`DanceHttpApiClient`, Video model, mobile test project) gain a `using TB.DanceDance.API.Contracts.Features.Groups;` alongside existing Contracts namespaces — 4 files touched.

## Test plan
- [x] `dotnet build` (backend + mobile + tests) — 0 errors
- [x] `dotnet test --filter "FullyQualifiedName~Group"` — 26/26 pass
- [x] `dotnet build ./src/mobile/TB.DanceDance.Mobile/ -c Release -f net10.0-android` — 0 errors
- [ ] Local stack smoke test (sign in, load home — `/api/groups/videos` should return the same payload; open a group — `/api/groups/{id}/videos`)
- [ ] CI (`pr-gated.yaml`) green

> Stylistically follows #71 (Comments) and #72 (Sharing); no overlapping files — can merge independently.