### PR TITLE
Move Events feature to vertical-slice folders

### DIFF
--- a/src/backend/Application/DependencyInjection.cs
+++ b/src/backend/Application/DependencyInjection.cs
@@ -1,4 +1,5 @@
-﻿using Application.Features.Sharing;
+﻿using Application.Features.Events;
+using Application.Features.Sharing;
 ﻿using Application.Features.Groups;
 ﻿using Application.Features.Comments;
 using Application.Services;
@@ -17,7 +18,6 @@ public static class DependencyInjection
             services
                 .AddScoped<IAccessService, AccessService>()
                 .AddScoped<IVideoService, VideoService>()
-                .AddScoped<IEventService, EventService>()
                 .AddScoped<IVideoUploaderService, VideoUploaderService>()
                 .AddScoped<ICommentService, CommentService>()
                 .AddScoped<ISharedLinkService, SharedLinkService>();
@@ -26,6 +26,7 @@ public static class DependencyInjection
 
             services.AddSharingFeature();
             services.AddGroupsFeature();
+            services.AddEventsFeature();
 
             return services;
         }

--- a/src/backend/Application/Features/Events/EventService.cs
+++ b/src/backend/Application/Features/Events/EventService.cs
@@ -1,8 +1,7 @@
 ﻿using Domain.Entities;
-using Domain.Services;
 using Microsoft.EntityFrameworkCore;
 
-namespace Application.Services;
+namespace Application.Features.Events;
 public class EventService : IEventService
 {
     private readonly IApplicationContext dbContext;

--- a/src/backend/Application/Features/Events/EventsModule.cs
+++ b/src/backend/Application/Features/Events/EventsModule.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Application.Features.Events;
+
+public static class EventsModule
+{
+    extension(IServiceCollection services)
+    {
+        public IServiceCollection AddEventsFeature()
+        {
+            services.AddScoped<IEventService, EventService>();
+            return services;
+        }
+    }
+}

--- a/src/backend/Application/Features/Events/IEventService.cs
+++ b/src/backend/Application/Features/Events/IEventService.cs
@@ -1,7 +1,7 @@
 ﻿
 using Domain.Entities;
 
-namespace Domain.Services;
+namespace Application.Features.Events;
 public interface IEventService
 {
     Task<ICollection<Event>> GetAllEvents(CancellationToken cancellationToken);

--- a/src/backend/TB.DanceDance.API.Contracts/Features/Events/CreateNewEventRequest.cs
+++ b/src/backend/TB.DanceDance.API.Contracts/Features/Events/CreateNewEventRequest.cs
@@ -1,7 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using TB.DanceDance.API.Contracts.Models;
 
-namespace TB.DanceDance.API.Contracts.Requests
+namespace TB.DanceDance.API.Contracts.Features.Events
 {
     public class CreateNewEventRequest
     {

--- a/src/backend/TB.DanceDance.API/ApiEndpoints.cs
+++ b/src/backend/TB.DanceDance.API/ApiEndpoints.cs
@@ -30,14 +30,6 @@ public static class ApiEndpoints
 
     }
 
-    public static class Event
-    {
-        private const string Base = $"{ApiBase}/events";
-
-        public const string AddEvent = $"{Base}";
-        public const string Videos = $"{Base}/{{eventId:guid}}/videos";
-    }
-
     public static class Converter
     {
         private const string Base = $"{ApiBase}/converter";

--- a/src/backend/TB.DanceDance.API/Controllers/EventsController.cs
+++ b/src/backend/TB.DanceDance.API/Controllers/EventsController.cs
@@ -1,4 +1,5 @@
-﻿using Application.Features.Groups;
+﻿using Application.Features.Events;
+using Application.Features.Groups;
 using Domain.Exceptions;
 using Domain.Services;
 using Infrastructure.Identity.IdentityResources;
@@ -90,25 +91,6 @@ public class EventsController : Controller
         return responseModel;
     }
 
-    [HttpPost]
-    [Route(ApiEndpoints.Event.AddEvent)]
-    public async Task<IActionResult> CreateEventAsync([FromBody] CreateNewEventRequest request, CancellationToken token)
-    {
-        if (!ModelState.IsValid)
-            return BadRequest(ModelState);
-
-
-        var @event = ContractMappers.MapFromNewEventRequestToEvent(request, User);
-
-        if (!ModelState.IsValid)
-            return BadRequest();
-
-        var createdEvent = await eventService.CreateEventAsync(@event,token);
-
-
-        return Created("", createdEvent); //todo
-    }
-
     [Route(ApiEndpoints.Video.Access.RequestAccess)]
     [HttpPost]
     public async Task<IActionResult> RequestAccess([FromBody] RequestAssigmentModelRequest requests, CancellationToken cancellationToken)
@@ -153,28 +135,6 @@ public class EventsController : Controller
         }
 
         return authToken;
-    }
-
-    [HttpGet]
-    [Route(ApiEndpoints.Event.Videos)]
-    public async Task<IActionResult> GetEventVideos([FromRoute] Guid eventId, CancellationToken token)
-    {
-        var userId = User.GetSubject();
-        var videos = await eventService
-            .GetVideos(eventId, userId, token);
-
-        if (videos.Length == 0)
-        {
-            var isAssigned = await accessService.DoesUserHasAccessToEvent(eventId, userId, token);
-            if (!isAssigned)
-                return Unauthorized();
-        }
-
-        var results = videos
-            .Select(r => ContractMappers.MapToVideoInformation(r))
-            .ToList();
-
-        return Ok(results);
     }
 
     [HttpGet]

--- a/src/backend/TB.DanceDance.API/Features/Events/EventRoutes.cs
+++ b/src/backend/TB.DanceDance.API/Features/Events/EventRoutes.cs
@@ -1,0 +1,10 @@
+namespace TB.DanceDance.API.Features.Events;
+
+public static class EventRoutes
+{
+    private const string ApiBase = "api";
+    private const string Base = $"{ApiBase}/events";
+
+    public const string AddEvent = $"{Base}";
+    public const string Videos = $"{Base}/{{eventId:guid}}/videos";
+}

--- a/src/backend/TB.DanceDance.API/Features/Events/EventsController.cs
+++ b/src/backend/TB.DanceDance.API/Features/Events/EventsController.cs
@@ -1,0 +1,64 @@
+using Application.Features.Events;
+using Domain.Services;
+using Infrastructure.Identity.IdentityResources;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using TB.DanceDance.API.Contracts.Features.Events;
+using TB.DanceDance.API.Extensions;
+using TB.DanceDance.API.Mappers;
+
+namespace TB.DanceDance.API.Features.Events;
+
+[Authorize(DanceDanceResources.WestCoastSwing.Scopes.ReadScope)]
+public class EventsController : Controller
+{
+    private readonly IAccessService accessService;
+    private readonly IEventService eventService;
+
+    public EventsController(IAccessService accessService, IEventService eventService)
+    {
+        this.accessService = accessService;
+        this.eventService = eventService;
+    }
+
+    [HttpPost]
+    [Route(EventRoutes.AddEvent)]
+    public async Task<IActionResult> CreateEventAsync([FromBody] CreateNewEventRequest request, CancellationToken token)
+    {
+        if (!ModelState.IsValid)
+            return BadRequest(ModelState);
+
+
+        var @event = ContractMappers.MapFromNewEventRequestToEvent(request, User);
+
+        if (!ModelState.IsValid)
+            return BadRequest();
+
+        var createdEvent = await eventService.CreateEventAsync(@event, token);
+
+
+        return Created("", createdEvent); //todo
+    }
+
+    [HttpGet]
+    [Route(EventRoutes.Videos)]
+    public async Task<IActionResult> GetEventVideos([FromRoute] Guid eventId, CancellationToken token)
+    {
+        var userId = User.GetSubject();
+        var videos = await eventService
+            .GetVideos(eventId, userId, token);
+
+        if (videos.Length == 0)
+        {
+            var isAssigned = await accessService.DoesUserHasAccessToEvent(eventId, userId, token);
+            if (!isAssigned)
+                return Unauthorized();
+        }
+
+        var results = videos
+            .Select(r => ContractMappers.MapToVideoInformation(r))
+            .ToList();
+
+        return Ok(results);
+    }
+}

--- a/src/backend/TB.DanceDance.API/Mappers/ContractMappers.cs
+++ b/src/backend/TB.DanceDance.API/Mappers/ContractMappers.cs
@@ -1,4 +1,5 @@
-﻿using TB.DanceDance.API.Contracts.Models;
+﻿using TB.DanceDance.API.Contracts.Features.Events;
+using TB.DanceDance.API.Contracts.Models;
 using TB.DanceDance.API.Contracts.Requests;
 using TB.DanceDance.API.Contracts.Responses;
 using TB.DanceDance.API.Extensions;

--- a/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/DanceHttpApiClient.cs
+++ b/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/DanceHttpApiClient.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System.Net.Http.Json;
+using TB.DanceDance.API.Contracts.Features.Events;
 using TB.DanceDance.API.Contracts.Features.Sharing;
 using TB.DanceDance.API.Contracts.Features.Groups;
 using TB.DanceDance.API.Contracts.Models;

--- a/src/tests/TB.DanceDance.Tests/Features/Events/EventServiceTests.cs
+++ b/src/tests/TB.DanceDance.Tests/Features/Events/EventServiceTests.cs
@@ -1,9 +1,9 @@
-﻿using Application.Services;
+﻿using Application.Features.Events;
 using Domain.Entities;
 using Infrastructure.Data;
 using TB.DanceDance.Tests.TestsFixture;
 
-namespace TB.DanceDance.Tests.Application;
+namespace TB.DanceDance.Tests.Features.Events;
 
 public class EventServiceTests : BaseTestClass
 {


### PR DESCRIPTION
## Summary
- Continues the vertical-slice pilot with the Events slice (2 endpoints — `POST /api/events` and `GET /api/events/{eventId}/videos`).
- New `Features/Events/EventsController` owns just those two endpoints. The existing `Controllers/EventsController.cs` keeps the four access-routed endpoints (`GetAllEventsAndGroups`, `GetAssignedGroupsAsync`, `RequestAccess`, manage requests) and will be renamed when the Access slice migrates.
- `IEventService` moves out of `Domain.Services` into `Application.Features.Events`.
- `EventRoutes` extracted from `ApiEndpoints.cs`; DI registration moved into a per-feature `AddEventsFeature()` extension in `EventsModule.cs`.
- `CreateNewEventRequest` moves to `Contracts/Features/Events/`; `ContractMappers` and the leftover access controller gain the matching usings.
- Mobile `DanceHttpApiClient` gains a `using TB.DanceDance.API.Contracts.Features.Events;`.
- `EventsAndGroupsResponse`, `UserEventsAndGroupsResponse`, and the access-request DTOs stay in `Contracts/Responses` + `Contracts/Requests` for the Access slice.

## Test plan
- [x] `dotnet build` (backend + mobile + tests) — 0 errors
- [x] `dotnet test --filter "FullyQualifiedName~Event"` — 30/30 pass
- [x] `dotnet build ./src/mobile/TB.DanceDance.Mobile/ -c Release -f net10.0-android` — 0 errors
- [ ] Local stack smoke test (create event, list event videos)
- [ ] CI (`pr-gated.yaml`) green

> Stylistically follows #71 / #72 / #73. The other 4 endpoints of the original `EventsController` move with the Access Management slice next.