### PR TITLE
Move Access Management feature to vertical-slice folders

### DIFF
--- a/src/backend/Application/DependencyInjection.cs
+++ b/src/backend/Application/DependencyInjection.cs
@@ -1,4 +1,5 @@
-﻿using Application.Features.Events;
+﻿using Application.Features.AccessManagement;
+using Application.Features.Events;
 using Application.Features.Sharing;
 ﻿using Application.Features.Groups;
 ﻿using Application.Features.Comments;
@@ -16,7 +17,6 @@ public static class DependencyInjection
         {
 
             services
-                .AddScoped<IAccessService, AccessService>()
                 .AddScoped<IVideoService, VideoService>()
                 .AddScoped<IVideoUploaderService, VideoUploaderService>()
                 .AddScoped<ICommentService, CommentService>()
@@ -27,6 +27,7 @@ public static class DependencyInjection
             services.AddSharingFeature();
             services.AddGroupsFeature();
             services.AddEventsFeature();
+            services.AddAccessManagementFeature();
 
             return services;
         }

--- a/src/backend/Application/Features/AccessManagement/AccessManagementModule.cs
+++ b/src/backend/Application/Features/AccessManagement/AccessManagementModule.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Application.Features.AccessManagement;
+
+public static class AccessManagementModule
+{
+    extension(IServiceCollection services)
+    {
+        public IServiceCollection AddAccessManagementFeature()
+        {
+            services.AddScoped<IAccessService, AccessService>();
+            services.AddScoped<IAccessManagementService, AccessManagementService>();
+            return services;
+        }
+    }
+}

--- a/src/backend/Application/Features/AccessManagement/AccessManagementService.cs
+++ b/src/backend/Application/Features/AccessManagement/AccessManagementService.cs
@@ -1,9 +1,8 @@
 ﻿using Domain.Entities;
 using Domain.Models;
-using Domain.Services;
 using Microsoft.EntityFrameworkCore;
 
-namespace Application.Services;
+namespace Application.Features.AccessManagement;
 
 public class AccessManagementService : IAccessManagementService
 {

--- a/src/backend/Application/Features/AccessManagement/AccessService.cs
+++ b/src/backend/Application/Features/AccessManagement/AccessService.cs
@@ -1,8 +1,7 @@
 ﻿using Domain.Entities;
-using Domain.Services;
 using Microsoft.EntityFrameworkCore;
 
-namespace Application.Services;
+namespace Application.Features.AccessManagement;
 
 public class AccessService : IAccessService
 {

--- a/src/backend/Application/Features/AccessManagement/IAccessManagementService.cs
+++ b/src/backend/Application/Features/AccessManagement/IAccessManagementService.cs
@@ -1,7 +1,7 @@
 ﻿using Domain.Entities;
 using Domain.Models;
 
-namespace Domain.Services;
+namespace Application.Features.AccessManagement;
 
 public interface IAccessManagementService
 {

--- a/src/backend/Application/Features/AccessManagement/IAccessService.cs
+++ b/src/backend/Application/Features/AccessManagement/IAccessService.cs
@@ -1,6 +1,6 @@
 ﻿using Domain.Entities;
 
-namespace Domain.Services;
+namespace Application.Features.AccessManagement;
 
 public interface IAccessService
 {

--- a/src/backend/Application/Features/Comments/CommentService.cs
+++ b/src/backend/Application/Features/Comments/CommentService.cs
@@ -1,4 +1,5 @@
 using Application.Extensions;
+using Application.Features.AccessManagement;
 using Domain.Entities;
 using Domain.Services;
 using Microsoft.EntityFrameworkCore;

--- a/src/backend/Application/Features/Sharing/SharedLinkService.cs
+++ b/src/backend/Application/Features/Sharing/SharedLinkService.cs
@@ -1,3 +1,4 @@
+using Application.Features.AccessManagement;
 using Domain.Entities;
 using Domain.Services;
 using Microsoft.EntityFrameworkCore;

--- a/src/backend/Application/Services/VideoService.cs
+++ b/src/backend/Application/Services/VideoService.cs
@@ -1,4 +1,5 @@
-﻿using Domain;
+﻿using Application.Features.AccessManagement;
+using Domain;
 using Domain.Entities;
 using Domain.Models;
 using Domain.Services;

--- a/src/backend/Infrastructure/DependencyInjection.cs
+++ b/src/backend/Infrastructure/DependencyInjection.cs
@@ -1,5 +1,4 @@
 ﻿using Application;
-using Application.Services;
 using Domain;
 using Domain.Exceptions;
 using Domain.Services;
@@ -27,8 +26,6 @@ public static class DependencyInjection
                 options.UseNpgsql(configuration.GetConnectionString("PostgreDb") ?? throw new AppException(
                     "PostgreDb connection string is null."));
             });
-
-            services.AddScoped<IAccessManagementService, AccessManagementService>();
 
             return services;
         }

--- a/src/backend/TB.DanceDance.API.Contracts/Features/AccessManagement/ApproveAccessRequest.cs
+++ b/src/backend/TB.DanceDance.API.Contracts/Features/AccessManagement/ApproveAccessRequest.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace TB.DanceDance.API.Contracts.Requests
+namespace TB.DanceDance.API.Contracts.Features.AccessManagement
 {
     public class ApproveAccessRequest
     {

--- a/src/backend/TB.DanceDance.API.Contracts/Features/AccessManagement/EventsAndGroupsResponse.cs
+++ b/src/backend/TB.DanceDance.API.Contracts/Features/AccessManagement/EventsAndGroupsResponse.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using TB.DanceDance.API.Contracts.Models;
 
-namespace TB.DanceDance.API.Contracts.Responses
+namespace TB.DanceDance.API.Contracts.Features.AccessManagement
 {
 
     public class EventsAndGroupsResponse : EventsAndGroups

--- a/src/backend/TB.DanceDance.API.Contracts/Features/AccessManagement/RequestAssigmentModelRequest.cs
+++ b/src/backend/TB.DanceDance.API.Contracts/Features/AccessManagement/RequestAssigmentModelRequest.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace TB.DanceDance.API.Contracts.Requests
+namespace TB.DanceDance.API.Contracts.Features.AccessManagement
 {
 
     public class RequestAssigmentModelRequest

--- a/src/backend/TB.DanceDance.API.Contracts/Features/AccessManagement/RequestedAccessesResponse.cs
+++ b/src/backend/TB.DanceDance.API.Contracts/Features/AccessManagement/RequestedAccessesResponse.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using TB.DanceDance.API.Contracts.Models;
 
-namespace TB.DanceDance.API.Contracts.Responses
+namespace TB.DanceDance.API.Contracts.Features.AccessManagement
 {
     public class RequestedAccessesResponse
     {

--- a/src/backend/TB.DanceDance.API/ApiEndpoints.cs
+++ b/src/backend/TB.DanceDance.API/ApiEndpoints.cs
@@ -16,18 +16,6 @@ public static class ApiEndpoints
         public const string GetUploadUrl = $"{Base}/upload";
         public const string RefreshUploadUrl = $"{Base}/upload/{{videoId:guid}}";
         public const string UpdateCommentSettings = $"{Base}/{{videoId:guid}}/comment-settings";
-
-
-        public static class Access
-        {
-            private const string Base = $"{Video.Base}/accesses";
-
-            public const string GetAll = $"{Base}";
-            public const string GetUserAccess = $"{Base}/my";
-            public const string RequestAccess = $"{Base}/request";
-            public const string ManageAccessRequests = $"{Base}/requests";
-        }
-
     }
 
     public static class Converter

--- a/src/backend/TB.DanceDance.API/Controllers/VideoController.cs
+++ b/src/backend/TB.DanceDance.API/Controllers/VideoController.cs
@@ -1,4 +1,5 @@
-﻿using Domain.Services;
+﻿using Application.Features.AccessManagement;
+using Domain.Services;
 using Infrastructure.Identity.IdentityResources;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/src/backend/TB.DanceDance.API/Features/AccessManagement/AccessController.cs
+++ b/src/backend/TB.DanceDance.API/Features/AccessManagement/AccessController.cs
@@ -1,19 +1,19 @@
-﻿using Application.Features.Events;
+using Application.Features.AccessManagement;
+using Application.Features.Events;
 using Application.Features.Groups;
 using Domain.Exceptions;
 using Domain.Services;
 using Infrastructure.Identity.IdentityResources;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using TB.DanceDance.API.Contracts.Requests;
-using TB.DanceDance.API.Contracts.Responses;
+using TB.DanceDance.API.Contracts.Features.AccessManagement;
 using TB.DanceDance.API.Extensions;
 using TB.DanceDance.API.Mappers;
 
-namespace TB.DanceDance.API.Controllers;
+namespace TB.DanceDance.API.Features.AccessManagement;
 
 [Authorize(DanceDanceResources.WestCoastSwing.Scopes.ReadScope)]
-public class EventsController : Controller
+public class AccessController : Controller
 {
     private readonly IAccessManagementService accessManagementService;
     private readonly IAccessService accessService;
@@ -21,10 +21,10 @@ public class EventsController : Controller
     private readonly IIdentityClient identityClient;
     private readonly IGroupService groupService;
 
-    public EventsController(
+    public AccessController(
         IAccessManagementService accessManagementService,
         IAccessService accessService,
-        IEventService eventService, 
+        IEventService eventService,
         IIdentityClient identityClient,
         IGroupService groupService
         )
@@ -36,7 +36,7 @@ public class EventsController : Controller
         this.groupService = groupService;
     }
 
-    [Route(ApiEndpoints.Video.Access.GetAll)]
+    [Route(AccessRoutes.GetAll)]
     [HttpGet]
     public async Task<EventsAndGroupsResponse> GetAllEventsAndGroups(CancellationToken token)
     {
@@ -54,7 +54,7 @@ public class EventsController : Controller
         };
     }
 
-    [Route(ApiEndpoints.Video.Access.GetUserAccess)]
+    [Route(AccessRoutes.GetUserAccess)]
     public async Task<UserEventsAndGroupsResponse> GetAssignedGroupsAsync(CancellationToken cancellationToken)
     {
         var user = User.GetSubject();
@@ -82,7 +82,7 @@ public class EventsController : Controller
         responseModel.Available.Groups = listOfGroups.Except(userGroups)
             .Select(group => ContractMappers.MapToGroupContract(group))
             .ToArray();
-        
+
         var myPendingRequests = await accessManagementService.GetPendingUserRequests(user, cancellationToken);
 
         responseModel.Pending.Events = myPendingRequests.Events;
@@ -91,7 +91,7 @@ public class EventsController : Controller
         return responseModel;
     }
 
-    [Route(ApiEndpoints.Video.Access.RequestAccess)]
+    [Route(AccessRoutes.RequestAccess)]
     [HttpPost]
     public async Task<IActionResult> RequestAccess([FromBody] RequestAssigmentModelRequest requests, CancellationToken cancellationToken)
     {
@@ -138,7 +138,7 @@ public class EventsController : Controller
     }
 
     [HttpGet]
-    [Route(ApiEndpoints.Video.Access.ManageAccessRequests)]
+    [Route(AccessRoutes.ManageAccessRequests)]
     public async Task<RequestedAccessesResponse> GetRequestAccessList(CancellationToken cancellationToken)
     {
         var userId = User.GetSubject();
@@ -150,8 +150,8 @@ public class EventsController : Controller
     }
 
     [HttpPost]
-    [Route(ApiEndpoints.Video.Access.ManageAccessRequests)]
-    public async Task<IActionResult> ApproveOrRejectRequestAccess([FromBody]ApproveAccessRequest requestBody, CancellationToken cancellationToken)
+    [Route(AccessRoutes.ManageAccessRequests)]
+    public async Task<IActionResult> ApproveOrRejectRequestAccess([FromBody] ApproveAccessRequest requestBody, CancellationToken cancellationToken)
     {
         var userId = User.GetSubject();
 
@@ -167,7 +167,4 @@ public class EventsController : Controller
         else
             return BadRequest();
     }
-
-
-
 }

--- a/src/backend/TB.DanceDance.API/Features/AccessManagement/AccessRoutes.cs
+++ b/src/backend/TB.DanceDance.API/Features/AccessManagement/AccessRoutes.cs
@@ -1,0 +1,12 @@
+namespace TB.DanceDance.API.Features.AccessManagement;
+
+public static class AccessRoutes
+{
+    private const string ApiBase = "api";
+    private const string Base = $"{ApiBase}/videos/accesses";
+
+    public const string GetAll = $"{Base}";
+    public const string GetUserAccess = $"{Base}/my";
+    public const string RequestAccess = $"{Base}/request";
+    public const string ManageAccessRequests = $"{Base}/requests";
+}

--- a/src/backend/TB.DanceDance.API/Features/Events/EventsController.cs
+++ b/src/backend/TB.DanceDance.API/Features/Events/EventsController.cs
@@ -1,3 +1,4 @@
+using Application.Features.AccessManagement;
 using Application.Features.Events;
 using Domain.Services;
 using Infrastructure.Identity.IdentityResources;

--- a/src/backend/TB.DanceDance.API/Mappers/ContractMappers.cs
+++ b/src/backend/TB.DanceDance.API/Mappers/ContractMappers.cs
@@ -1,4 +1,5 @@
-﻿using TB.DanceDance.API.Contracts.Features.Events;
+﻿using TB.DanceDance.API.Contracts.Features.AccessManagement;
+using TB.DanceDance.API.Contracts.Features.Events;
 using TB.DanceDance.API.Contracts.Models;
 using TB.DanceDance.API.Contracts.Requests;
 using TB.DanceDance.API.Contracts.Responses;
@@ -60,7 +61,7 @@ public class ContractMappers
         };
     }
 
-    public static Contracts.Responses.RequestedAccessesResponse MapToAccessRequests(ICollection<Domain.Models.RequestedAccess> accessRequests)
+    public static RequestedAccessesResponse MapToAccessRequests(ICollection<Domain.Models.RequestedAccess> accessRequests)
     {
         return new RequestedAccessesResponse()
         {

--- a/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/DanceHttpApiClient.cs
+++ b/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/DanceHttpApiClient.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System.Net.Http.Json;
+using TB.DanceDance.API.Contracts.Features.AccessManagement;
 using TB.DanceDance.API.Contracts.Features.Events;
 using TB.DanceDance.API.Contracts.Features.Sharing;
 using TB.DanceDance.API.Contracts.Features.Groups;

--- a/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/IDanceHttpApiClient.cs
+++ b/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/IDanceHttpApiClient.cs
@@ -1,4 +1,5 @@
-﻿using TB.DanceDance.API.Contracts.Features.Sharing;
+﻿using TB.DanceDance.API.Contracts.Features.AccessManagement;
+using TB.DanceDance.API.Contracts.Features.Sharing;
 ﻿using TB.DanceDance.API.Contracts.Features.Groups;
 using TB.DanceDance.API.Contracts.Models;
 using TB.DanceDance.API.Contracts.Requests;

--- a/src/mobile/TB.DanceDance.Mobile/PageModels/GetAccessPageModel.cs
+++ b/src/mobile/TB.DanceDance.Mobile/PageModels/GetAccessPageModel.cs
@@ -1,6 +1,7 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
+using TB.DanceDance.API.Contracts.Features.AccessManagement;
 using TB.DanceDance.API.Contracts.Models;
 using TB.DanceDance.API.Contracts.Requests;
 using TB.DanceDance.Mobile.Library.Services.DanceApi;

--- a/src/tests/TB.DanceDance.Mobile.Tests/IntegrationTests/DanceHttpApiClientTests.cs
+++ b/src/tests/TB.DanceDance.Mobile.Tests/IntegrationTests/DanceHttpApiClientTests.cs
@@ -1,5 +1,6 @@
 ﻿using NSubstitute;
 using System.Text.Json;
+using TB.DanceDance.API.Contracts.Features.AccessManagement;
 using TB.DanceDance.API.Contracts.Features.Sharing;
 using TB.DanceDance.API.Contracts.Features.Groups;
 using TB.DanceDance.API.Contracts.Models;

--- a/src/tests/TB.DanceDance.Tests/Application/VideoServiceTests.cs
+++ b/src/tests/TB.DanceDance.Tests/Application/VideoServiceTests.cs
@@ -1,4 +1,5 @@
-﻿using Application.Services;
+﻿using Application.Features.AccessManagement;
+using Application.Services;
 using Domain;
 using Domain.Entities;
 using Domain.Models;

--- a/src/tests/TB.DanceDance.Tests/Features/AccessManagement/AccessManagementServiceTests.cs
+++ b/src/tests/TB.DanceDance.Tests/Features/AccessManagement/AccessManagementServiceTests.cs
@@ -1,10 +1,10 @@
-﻿using Application.Services;
+﻿using Application.Features.AccessManagement;
 using Domain.Entities;
 using Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using TB.DanceDance.Tests.TestsFixture;
 
-namespace TB.DanceDance.Tests.Application;
+namespace TB.DanceDance.Tests.Features.AccessManagement;
 
 public class AccessManagementServiceTests : BaseTestClass
 {

--- a/src/tests/TB.DanceDance.Tests/Features/AccessManagement/AccessServiceTests.cs
+++ b/src/tests/TB.DanceDance.Tests/Features/AccessManagement/AccessServiceTests.cs
@@ -1,9 +1,9 @@
-﻿using Application.Services;
+﻿using Application.Features.AccessManagement;
 using Infrastructure.Data;
 using Domain.Entities;
 using TB.DanceDance.Tests.TestsFixture;
 
-namespace TB.DanceDance.Tests.Application;
+namespace TB.DanceDance.Tests.Features.AccessManagement;
 
 public class AccessServiceTests : BaseTestClass
 {

--- a/src/tests/TB.DanceDance.Tests/Features/Sharing/SharedLinkServiceTests.cs
+++ b/src/tests/TB.DanceDance.Tests/Features/Sharing/SharedLinkServiceTests.cs
@@ -1,3 +1,4 @@
+using Application.Features.AccessManagement;
 using Application.Features.Sharing;
 using Application.Services;
 using Domain.Entities;


### PR DESCRIPTION
## Summary
- Final pilot for the Access Management slice (4 endpoints — list all events+groups, list user accesses with pending, request access, list+approve/reject access requests).
- The leftover `Controllers/EventsController.cs` is renamed to `Features/AccessManagement/AccessController.cs`; the only Events-routed endpoints already moved with #74.
- `IAccessService` and `IAccessManagementService` move out of `Domain.Services` into `Application.Features.AccessManagement`.
- `AccessManagementService` was previously registered in `Infrastructure/DependencyInjection.cs`; its registration consolidates into the new `AddAccessManagementFeature()` extension in `AccessManagementModule.cs` alongside `IAccessService`.
- `AccessRoutes` extracted from `ApiEndpoints.cs` (the `Video.Access` nested class is removed); routes stay at `/api/videos/accesses/*` so URLs are unchanged.
- Four DTOs (`ApproveAccessRequest`, `RequestAssigmentModelRequest`, `EventsAndGroupsResponse`, `RequestedAccessesResponse`) move to `Contracts/Features/AccessManagement/`.
- Backend consumers of `IAccessService` (Sharing, Comments, `VideoService`, `VideoController`, the Events controller, `VideoServiceTests`, `SharedLinkServiceTests`) gain the new namespace using.
- `ContractMappers` and the Access controller pick up the new `Contracts.Features.AccessManagement` namespace.
- Mobile (`DanceHttpApiClient`/`IDanceHttpApiClient`, `GetAccessPageModel`, mobile test project) gain a using for the new contracts namespace.

## Test plan
- [x] `dotnet build` (backend + mobile + tests) — 0 errors
- [x] `dotnet test --filter "FullyQualifiedName~Access"` — 41/41 pass
- [x] `dotnet build ./src/mobile/TB.DanceDance.Mobile/ -c Release -f net10.0-android` — 0 errors
- [ ] Local stack smoke test (open Get Access screen, request access, approve/decline as admin)
- [ ] CI green

> **Stacked on #74 (Events).** Targets `worktree-vsa-events-pilot`. Once #74 merges, retarget this PR to `maintenance/vertical-slice-architecture` (or merge sequentially via the Events branch).