### PR TITLE
Move Videos feature to vertical-slice folders

### DIFF
--- a/src/backend/Application/DependencyInjection.cs
+++ b/src/backend/Application/DependencyInjection.cs
@@ -1,9 +1,9 @@
 ﻿using Application.Features.AccessManagement;
 using Application.Features.Events;
 using Application.Features.Sharing;
+using Application.Features.Videos;
 ﻿using Application.Features.Groups;
 ﻿using Application.Features.Comments;
-using Application.Services;
 using Domain.Services;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -17,8 +17,6 @@ public static class DependencyInjection
         {
 
             services
-                .AddScoped<IVideoService, VideoService>()
-                .AddScoped<IVideoUploaderService, VideoUploaderService>()
                 .AddScoped<ICommentService, CommentService>()
                 .AddScoped<ISharedLinkService, SharedLinkService>();
 
@@ -28,6 +26,7 @@ public static class DependencyInjection
             services.AddGroupsFeature();
             services.AddEventsFeature();
             services.AddAccessManagementFeature();
+            services.AddVideosFeature();
 
             return services;
         }

--- a/src/backend/Application/Features/Videos/IVideoService.cs
+++ b/src/backend/Application/Features/Videos/IVideoService.cs
@@ -1,8 +1,8 @@
 ﻿using Domain.Entities;
 using Domain.Models;
-using TB.DanceDance.API.Contracts.Requests;
+using TB.DanceDance.API.Contracts.Features.Videos;
 
-namespace Domain.Services;
+namespace Application.Features.Videos;
 
 public interface IVideoService
 {

--- a/src/backend/Application/Features/Videos/IVideoUploaderService.cs
+++ b/src/backend/Application/Features/Videos/IVideoUploaderService.cs
@@ -1,7 +1,7 @@
 ﻿using Domain.Entities;
 using Domain.Models;
 
-namespace Domain.Services;
+namespace Application.Features.Videos;
 
 public interface IVideoUploaderService
 {

--- a/src/backend/Application/Features/Videos/VideoService.cs
+++ b/src/backend/Application/Features/Videos/VideoService.cs
@@ -4,9 +4,9 @@ using Domain.Entities;
 using Domain.Models;
 using Domain.Services;
 using Microsoft.EntityFrameworkCore;
-using TB.DanceDance.API.Contracts.Requests;
+using TB.DanceDance.API.Contracts.Features.Videos;
 
-namespace Application.Services;
+namespace Application.Features.Videos;
 
 public class VideoService : IVideoService
 {

--- a/src/backend/Application/Features/Videos/VideoUploaderService.cs
+++ b/src/backend/Application/Features/Videos/VideoUploaderService.cs
@@ -4,7 +4,7 @@ using Domain.Models;
 using Domain.Services;
 using Microsoft.EntityFrameworkCore;
 
-namespace Application.Services;
+namespace Application.Features.Videos;
 
 public class VideoUploaderService : IVideoUploaderService
 {

--- a/src/backend/Application/Features/Videos/VideosModule.cs
+++ b/src/backend/Application/Features/Videos/VideosModule.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Application.Features.Videos;
+
+public static class VideosModule
+{
+    extension(IServiceCollection services)
+    {
+        public IServiceCollection AddVideosFeature()
+        {
+            services.AddScoped<IVideoService, VideoService>();
+            services.AddScoped<IVideoUploaderService, VideoUploaderService>();
+            return services;
+        }
+    }
+}

--- a/src/backend/TB.DanceDance.API.Contracts/Features/Groups/GroupWithVideosResponse.cs
+++ b/src/backend/TB.DanceDance.API.Contracts/Features/Groups/GroupWithVideosResponse.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using TB.DanceDance.API.Contracts.Responses;
+using TB.DanceDance.API.Contracts.Features.Videos;
 
 namespace TB.DanceDance.API.Contracts.Features.Groups
 {

--- a/src/backend/TB.DanceDance.API.Contracts/Features/Videos/SharedVideoInformationRequest.cs
+++ b/src/backend/TB.DanceDance.API.Contracts/Features/Videos/SharedVideoInformationRequest.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
 
-namespace TB.DanceDance.API.Contracts.Requests
+namespace TB.DanceDance.API.Contracts.Features.Videos
 {
 
     public class SharedVideoInformationRequest

--- a/src/backend/TB.DanceDance.API.Contracts/Features/Videos/UpdateVideoCommentSettingsRequest.cs
+++ b/src/backend/TB.DanceDance.API.Contracts/Features/Videos/UpdateVideoCommentSettingsRequest.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 
-namespace TB.DanceDance.API.Contracts.Requests
+namespace TB.DanceDance.API.Contracts.Features.Videos
 {
     public class UpdateVideoCommentSettingsRequest
     {

--- a/src/backend/TB.DanceDance.API.Contracts/Features/Videos/UploadVideoInformationResponse.cs
+++ b/src/backend/TB.DanceDance.API.Contracts/Features/Videos/UploadVideoInformationResponse.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace TB.DanceDance.API.Contracts.Models
+namespace TB.DanceDance.API.Contracts.Features.Videos
 {
     public class UploadVideoInformationResponse
     {

--- a/src/backend/TB.DanceDance.API.Contracts/Features/Videos/VideoInformationResponse.cs
+++ b/src/backend/TB.DanceDance.API.Contracts/Features/Videos/VideoInformationResponse.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace TB.DanceDance.API.Contracts.Responses
+namespace TB.DanceDance.API.Contracts.Features.Videos
 {
     public class VideoInformationResponse : VideoInformationModel
     {

--- a/src/backend/TB.DanceDance.API.Contracts/Features/Videos/VideoRenameRequest.cs
+++ b/src/backend/TB.DanceDance.API.Contracts/Features/Videos/VideoRenameRequest.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace TB.DanceDance.API.Contracts.Requests
+namespace TB.DanceDance.API.Contracts.Features.Videos
 {
     public class VideoRenameRequest
     {

--- a/src/backend/TB.DanceDance.API/ApiEndpoints.cs
+++ b/src/backend/TB.DanceDance.API/ApiEndpoints.cs
@@ -4,20 +4,6 @@ public static class ApiEndpoints
 {
     private const string ApiBase = "api";
 
-    public static class Video
-    {
-        private const string Base = $"{ApiBase}/videos";
-
-        public const string MyVideos = $"{Base}/my";
-        public const string GetSingle = $"{Base}/{{guid}}";
-        public const string GetStream = $"{Base}/{{guid}}/stream";
-
-        public const string Rename = $"{Base}/{{videoId:guid}}/rename";
-        public const string GetUploadUrl = $"{Base}/upload";
-        public const string RefreshUploadUrl = $"{Base}/upload/{{videoId:guid}}";
-        public const string UpdateCommentSettings = $"{Base}/{{videoId:guid}}/comment-settings";
-    }
-
     public static class Converter
     {
         private const string Base = $"{ApiBase}/converter";

--- a/src/backend/TB.DanceDance.API/Controllers/ConverterController.cs
+++ b/src/backend/TB.DanceDance.API/Controllers/ConverterController.cs
@@ -1,3 +1,4 @@
+using Application.Features.Videos;
 using Domain.Services;
 using Infrastructure.Identity.IdentityResources;
 using Microsoft.AspNetCore.Authorization;

--- a/src/backend/TB.DanceDance.API/Features/Groups/GroupController.cs
+++ b/src/backend/TB.DanceDance.API/Features/Groups/GroupController.cs
@@ -4,6 +4,7 @@ using Infrastructure.Identity.IdentityResources;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using TB.DanceDance.API.Contracts.Features.Groups;
+using TB.DanceDance.API.Contracts.Features.Videos;
 using TB.DanceDance.API.Contracts.Responses;
 using TB.DanceDance.API.Extensions;
 using TB.DanceDance.API.Mappers;

--- a/src/backend/TB.DanceDance.API/Features/Sharing/ShareController.cs
+++ b/src/backend/TB.DanceDance.API/Features/Sharing/ShareController.cs
@@ -1,4 +1,5 @@
 using Application.Features.Sharing;
+using Application.Features.Videos;
 using Domain.Services;
 using Infrastructure.Identity.IdentityResources;
 using Microsoft.AspNetCore.Authorization;

--- a/src/backend/TB.DanceDance.API/Features/Videos/VideoController.cs
+++ b/src/backend/TB.DanceDance.API/Features/Videos/VideoController.cs
@@ -1,14 +1,13 @@
 ﻿using Application.Features.AccessManagement;
-using Domain.Services;
+using Application.Features.Videos;
 using Infrastructure.Identity.IdentityResources;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using TB.DanceDance.API.Contracts.Models;
-using TB.DanceDance.API.Contracts.Requests;
+using TB.DanceDance.API.Contracts.Features.Videos;
 using TB.DanceDance.API.Extensions;
 using TB.DanceDance.API.Mappers;
 
-namespace TB.DanceDance.API.Controllers;
+namespace TB.DanceDance.API.Features.Videos;
 
 [Authorize(DanceDanceResources.WestCoastSwing.Scopes.ReadScope)]
 public class VideoController : Controller
@@ -27,7 +26,7 @@ public class VideoController : Controller
     private readonly ILogger<VideoController> logger;
 
 
-    [Route(ApiEndpoints.Video.MyVideos)]
+    [Route(VideoRoutes.MyVideos)]
     public async Task<IActionResult> MyVideos(CancellationToken cancellationToken)
     {
         var videos = await accessService.GetUserPrivateVideos(User.GetSubject(), cancellationToken);
@@ -36,7 +35,7 @@ public class VideoController : Controller
         return new OkObjectResult(apiModel);
     }
     
-    [Route(ApiEndpoints.Video.GetSingle)]
+    [Route(VideoRoutes.GetSingle)]
     [HttpGet]
     public async Task<IActionResult> GetInformationAsync(string guid, CancellationToken cancellationToken)
     {
@@ -52,7 +51,7 @@ public class VideoController : Controller
         return new OkObjectResult(results);
     }
 
-    [Route(ApiEndpoints.Video.GetStream)]
+    [Route(VideoRoutes.GetStream)]
     [HttpGet]
     public async Task<IActionResult> GetStreamAsync(string guid, CancellationToken cancellationToken)
     {
@@ -76,7 +75,7 @@ public class VideoController : Controller
         return File(stream, "video/mp4", enableRangeProcessing: true);
     }
 
-    [Route(ApiEndpoints.Video.Rename)]
+    [Route(VideoRoutes.Rename)]
     [HttpPost]
     public async Task<IActionResult> RenameVideo([FromRoute] Guid videoId, [FromBody] VideoRenameRequest input, CancellationToken cancellationToken)
     {
@@ -92,7 +91,7 @@ public class VideoController : Controller
     }
 
     [HttpGet]
-    [Route(ApiEndpoints.Video.RefreshUploadUrl)]
+    [Route(VideoRoutes.RefreshUploadUrl)]
     public async Task<ActionResult<UploadVideoInformationResponse>> GetUploadInformation([FromRoute]Guid videoId, CancellationToken cancellationToken)
     {
         string user  = User.GetSubject();
@@ -111,7 +110,7 @@ public class VideoController : Controller
         };
     }
 
-    [Route(ApiEndpoints.Video.GetUploadUrl)]
+    [Route(VideoRoutes.GetUploadUrl)]
     [HttpPost]
     public async Task<ActionResult<UploadVideoInformationResponse>> GetUploadInformation(
         [FromBody] SharedVideoInformationRequest sharedVideoInformation,
@@ -208,7 +207,7 @@ public class VideoController : Controller
     /// Updates the comment visibility setting for a video. Only the video owner can update this.
     /// </summary>
     [HttpPut]
-    [Route(ApiEndpoints.Video.UpdateCommentSettings)]
+    [Route(VideoRoutes.UpdateCommentSettings)]
     public async Task<IActionResult> UpdateCommentSettings(
         [FromRoute] Guid videoId,
         [FromBody] UpdateVideoCommentSettingsRequest request,

--- a/src/backend/TB.DanceDance.API/Features/Videos/VideoRoutes.cs
+++ b/src/backend/TB.DanceDance.API/Features/Videos/VideoRoutes.cs
@@ -1,0 +1,15 @@
+namespace TB.DanceDance.API.Features.Videos;
+
+public static class VideoRoutes
+{
+    private const string ApiBase = "api";
+    private const string Base = $"{ApiBase}/videos";
+
+    public const string MyVideos = $"{Base}/my";
+    public const string GetSingle = $"{Base}/{{guid}}";
+    public const string GetStream = $"{Base}/{{guid}}/stream";
+    public const string Rename = $"{Base}/{{videoId:guid}}/rename";
+    public const string GetUploadUrl = $"{Base}/upload";
+    public const string RefreshUploadUrl = $"{Base}/upload/{{videoId:guid}}";
+    public const string UpdateCommentSettings = $"{Base}/{{videoId:guid}}/comment-settings";
+}

--- a/src/backend/TB.DanceDance.API/Mappers/ContractMappers.cs
+++ b/src/backend/TB.DanceDance.API/Mappers/ContractMappers.cs
@@ -1,5 +1,6 @@
 ﻿using TB.DanceDance.API.Contracts.Features.AccessManagement;
 using TB.DanceDance.API.Contracts.Features.Events;
+using TB.DanceDance.API.Contracts.Features.Videos;
 using TB.DanceDance.API.Contracts.Models;
 using TB.DanceDance.API.Contracts.Requests;
 using TB.DanceDance.API.Contracts.Responses;

--- a/src/mobile/TB.DanceDance.Mobile.Library/Data/Models/Video.cs
+++ b/src/mobile/TB.DanceDance.Mobile.Library/Data/Models/Video.cs
@@ -1,5 +1,5 @@
 ﻿using TB.DanceDance.API.Contracts.Features.Groups;
-using TB.DanceDance.API.Contracts.Responses;
+using TB.DanceDance.API.Contracts.Features.Videos;
 
 namespace TB.DanceDance.Mobile.Library.Data.Models;
 

--- a/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/DanceHttpApiClient.cs
+++ b/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/DanceHttpApiClient.cs
@@ -4,6 +4,7 @@ using TB.DanceDance.API.Contracts.Features.AccessManagement;
 using TB.DanceDance.API.Contracts.Features.Events;
 using TB.DanceDance.API.Contracts.Features.Sharing;
 using TB.DanceDance.API.Contracts.Features.Groups;
+using TB.DanceDance.API.Contracts.Features.Videos;
 using TB.DanceDance.API.Contracts.Models;
 using TB.DanceDance.API.Contracts.Requests;
 using TB.DanceDance.API.Contracts.Responses;

--- a/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/IDanceHttpApiClient.cs
+++ b/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/IDanceHttpApiClient.cs
@@ -1,6 +1,7 @@
 ﻿using TB.DanceDance.API.Contracts.Features.AccessManagement;
 using TB.DanceDance.API.Contracts.Features.Sharing;
 ﻿using TB.DanceDance.API.Contracts.Features.Groups;
+using TB.DanceDance.API.Contracts.Features.Videos;
 using TB.DanceDance.API.Contracts.Models;
 using TB.DanceDance.API.Contracts.Requests;
 using TB.DanceDance.API.Contracts.Responses;

--- a/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/VideoUploader.cs
+++ b/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/VideoUploader.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using System.Threading.Channels;
+using TB.DanceDance.API.Contracts.Features.Videos;
 using TB.DanceDance.API.Contracts.Models;
 using TB.DanceDance.API.Contracts.Requests;
 using TB.DanceDance.Mobile.Library.Data;

--- a/src/mobile/TB.DanceDance.Mobile/PageModels/GetAccessPageModel.cs
+++ b/src/mobile/TB.DanceDance.Mobile/PageModels/GetAccessPageModel.cs
@@ -2,6 +2,7 @@
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
 using TB.DanceDance.API.Contracts.Features.AccessManagement;
+using TB.DanceDance.API.Contracts.Features.Videos;
 using TB.DanceDance.API.Contracts.Models;
 using TB.DanceDance.API.Contracts.Requests;
 using TB.DanceDance.Mobile.Library.Services.DanceApi;

--- a/src/tests/TB.DanceDance.Mobile.Tests/IntegrationTests/DanceHttpApiClientTests.cs
+++ b/src/tests/TB.DanceDance.Mobile.Tests/IntegrationTests/DanceHttpApiClientTests.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using TB.DanceDance.API.Contracts.Features.AccessManagement;
 using TB.DanceDance.API.Contracts.Features.Sharing;
 using TB.DanceDance.API.Contracts.Features.Groups;
+using TB.DanceDance.API.Contracts.Features.Videos;
 using TB.DanceDance.API.Contracts.Models;
 using TB.DanceDance.API.Contracts.Requests;
 using TB.DanceDance.API.Contracts.Responses;

--- a/src/tests/TB.DanceDance.Mobile.Tests/IntegrationTests/UploadWorkerTests.cs
+++ b/src/tests/TB.DanceDance.Mobile.Tests/IntegrationTests/UploadWorkerTests.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
 using System.Threading.Channels;
+using TB.DanceDance.API.Contracts.Features.Videos;
 using TB.DanceDance.API.Contracts.Models;
 using TB.DanceDance.Mobile.Library.Data;
 using TB.DanceDance.Mobile.Library.Data.Models.Storage;

--- a/src/tests/TB.DanceDance.Mobile.Tests/IntegrationTests/VideoUploaderTests.cs
+++ b/src/tests/TB.DanceDance.Mobile.Tests/IntegrationTests/VideoUploaderTests.cs
@@ -2,6 +2,7 @@
 using Microsoft.Maui.Devices;
 using NSubstitute;
 using System.Threading.Channels;
+using TB.DanceDance.API.Contracts.Features.Videos;
 using TB.DanceDance.API.Contracts.Models;
 using TB.DanceDance.API.Contracts.Requests;
 using TB.DanceDance.Mobile.Library.Data;

--- a/src/tests/TB.DanceDance.Tests/Features/Sharing/SharedLinkServiceTests.cs
+++ b/src/tests/TB.DanceDance.Tests/Features/Sharing/SharedLinkServiceTests.cs
@@ -1,8 +1,6 @@
 using Application.Features.AccessManagement;
 using Application.Features.Sharing;
-using Application.Services;
 using Domain.Entities;
-using Domain.Services;
 using Infrastructure.Data;
 using TB.DanceDance.Tests.TestsFixture;
 

--- a/src/tests/TB.DanceDance.Tests/Features/Videos/VideoServiceTests.cs
+++ b/src/tests/TB.DanceDance.Tests/Features/Videos/VideoServiceTests.cs
@@ -1,5 +1,5 @@
 ﻿using Application.Features.AccessManagement;
-using Application.Services;
+using Application.Features.Videos;
 using Domain;
 using Domain.Entities;
 using Domain.Models;
@@ -8,10 +8,10 @@ using Infrastructure.Data;
 using Infrastructure.Data.BlobStorage;
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
-using TB.DanceDance.API.Contracts.Requests;
+using TB.DanceDance.API.Contracts.Features.Videos;
 using TB.DanceDance.Tests.TestsFixture;
 
-namespace TB.DanceDance.Tests.Application;
+namespace TB.DanceDance.Tests.Features.Videos;
 
 public class VideoServiceTests : BaseTestClass
 {

--- a/src/tests/TB.DanceDance.Tests/Features/Videos/VideoUploaderTests.cs
+++ b/src/tests/TB.DanceDance.Tests/Features/Videos/VideoUploaderTests.cs
@@ -1,11 +1,11 @@
-﻿using Application.Services;
+﻿using Application.Features.Videos;
 using Domain;
 using Infrastructure.Data;
 using Infrastructure.Data.BlobStorage;
 using Microsoft.EntityFrameworkCore;
 using TB.DanceDance.Tests.TestsFixture;
 
-namespace TB.DanceDance.Tests.Application;
+namespace TB.DanceDance.Tests.Features.Videos;
 
 public class VideoUploaderTests : BaseTestClass
 {


### PR DESCRIPTION
Co-locates the Videos slice (controller, services, interfaces, DTOs, tests) under `Features/Videos/` folders in each project.

## Changes
- `Application/Features/Videos/` — `VideoService`, `VideoUploaderService`, their interfaces, and new `VideosModule` (per-feature DI extension via C# 14 `extension(IServiceCollection)` block)
- `TB.DanceDance.API/Features/Videos/` — `VideoController`, new `VideoRoutes` constants
- `TB.DanceDance.API.Contracts/Features/Videos/` — `VideoInformationResponse`, `UploadVideoInformationResponse`, `VideoRenameRequest`, `SharedVideoInformationRequest`, `UpdateVideoCommentSettingsRequest`
- `tests/Features/Videos/` — `VideoServiceTests`, `VideoUploaderTests`
- Consumer using-directives updated across API, Mobile library, MAUI app, and test projects
- `ApiEndpoints.Video` block removed (constants live in `VideoRoutes` now)
- `Application/DependencyInjection.cs` switched to `services.AddVideosFeature()`

Converter-facing contracts (`UpdateVideoInfoRequest`, `VideoToTransformResponse`, `GetPublishSasResponse`, `UploadConvertedVideoResponse`) stay in `Requests/` and `Responses/` for now; they'll move with the upcoming Video Conversion slice.

> Stacked on top of #75 (Access Management slice). Targets `worktree-vsa-access-pilot`.

## Test plan
- [x] `dotnet build` of API, Application, Domain, Infrastructure, Contracts, Tests, Mobile.Library, Mobile.Tests — clean
- [x] `dotnet build` of MAUI Android target — clean
- [x] `dotnet test --filter "FullyQualifiedName~Video"` against `TB.DanceDance.Tests` — 80 passed
- [x] `dotnet test` against `TB.DanceDance.Mobile.Tests` — 28 passed