### PR TITLE
Move Conversion feature to vertical-slice folders

### DIFF
--- a/src/backend/TB.DanceDance.API.Contracts/Features/Conversion/GetPublishSasResponse.cs
+++ b/src/backend/TB.DanceDance.API.Contracts/Features/Conversion/GetPublishSasResponse.cs
@@ -1,4 +1,4 @@
-﻿namespace TB.DanceDance.API.Contracts.Responses
+﻿namespace TB.DanceDance.API.Contracts.Features.Conversion
 {
     public class GetPublishSasResponse
     {

--- a/src/backend/TB.DanceDance.API.Contracts/Features/Conversion/UpdateVideoInfoRequest.cs
+++ b/src/backend/TB.DanceDance.API.Contracts/Features/Conversion/UpdateVideoInfoRequest.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
 
-namespace TB.DanceDance.API.Contracts.Requests
+namespace TB.DanceDance.API.Contracts.Features.Conversion
 {
     public class UpdateVideoInfoRequest
     {

--- a/src/backend/TB.DanceDance.API.Contracts/Features/Conversion/UploadConvertedVideoResponse.cs
+++ b/src/backend/TB.DanceDance.API.Contracts/Features/Conversion/UploadConvertedVideoResponse.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace TB.DanceDance.API.Contracts.Responses
+namespace TB.DanceDance.API.Contracts.Features.Conversion
 {
     public class UploadConvertedVideoResponse
     {

--- a/src/backend/TB.DanceDance.API.Contracts/Features/Conversion/VideoToTransformResponse.cs
+++ b/src/backend/TB.DanceDance.API.Contracts/Features/Conversion/VideoToTransformResponse.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace TB.DanceDance.API.Contracts.Responses
+namespace TB.DanceDance.API.Contracts.Features.Conversion
 {
     public class VideoToTransformResponse
     {

--- a/src/backend/TB.DanceDance.API/ApiEndpoints.cs
+++ b/src/backend/TB.DanceDance.API/ApiEndpoints.cs
@@ -1,18 +1,7 @@
-﻿namespace TB.DanceDance.API;
+namespace TB.DanceDance.API;
 
 public static class ApiEndpoints
 {
-    private const string ApiBase = "api";
-
-    public static class Converter
-    {
-        private const string Base = $"{ApiBase}/converter";
-
-        public const string Videos = $"{Base}/videos";
-        public const string Upload = $"{Base}/videos/{{videoId}}/publish";
-        public const string GetPublishSas = $"{Base}/videos/{{videoId}}/sas";
-    }
-    
     public static class Info
     {
         public const string AllEndpoints = "/.endpoints";

--- a/src/backend/TB.DanceDance.API/Features/Conversion/ConversionRoutes.cs
+++ b/src/backend/TB.DanceDance.API/Features/Conversion/ConversionRoutes.cs
@@ -1,0 +1,11 @@
+namespace TB.DanceDance.API.Features.Conversion;
+
+public static class ConversionRoutes
+{
+    private const string ApiBase = "api";
+    private const string Base = $"{ApiBase}/converter";
+
+    public const string Videos = $"{Base}/videos";
+    public const string Upload = $"{Base}/videos/{{videoId}}/publish";
+    public const string GetPublishSas = $"{Base}/videos/{{videoId}}/sas";
+}

--- a/src/backend/TB.DanceDance.API/Features/Conversion/ConverterController.cs
+++ b/src/backend/TB.DanceDance.API/Features/Conversion/ConverterController.cs
@@ -1,12 +1,10 @@
 using Application.Features.Videos;
-using Domain.Services;
 using Infrastructure.Identity.IdentityResources;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using TB.DanceDance.API.Contracts.Requests;
-using TB.DanceDance.API.Contracts.Responses;
+using TB.DanceDance.API.Contracts.Features.Conversion;
 
-namespace TB.DanceDance.API.Controllers;
+namespace TB.DanceDance.API.Features.Conversion;
 
 [Authorize(DanceDanceResources.WestCoastSwing.Scopes.WriteConvert)]
 public class ConverterController : Controller
@@ -19,7 +17,7 @@ public class ConverterController : Controller
     }
 
     [HttpGet]
-    [Route(ApiEndpoints.Converter.Videos)]
+    [Route(ConversionRoutes.Videos)]
     public async Task<IActionResult> GetVideosToConvert(CancellationToken cancellationToken)
     {
         var video = await videoUploaderService.GetNextVideoToTransformAsync(cancellationToken);
@@ -38,7 +36,7 @@ public class ConverterController : Controller
     }
 
     [HttpPost]
-    [Route(ApiEndpoints.Converter.Videos)]
+    [Route(ConversionRoutes.Videos)]
     public async Task<IActionResult> UpdateVideoInfo([FromBody] UpdateVideoInfoRequest publishVideo, CancellationToken cancellationToken)
     {
         if (!ModelState.IsValid)
@@ -60,7 +58,7 @@ public class ConverterController : Controller
     }
 
     [HttpGet]
-    [Route(ApiEndpoints.Converter.GetPublishSas)]
+    [Route(ConversionRoutes.GetPublishSas)]
     public async Task<IActionResult> GetPublishSas([FromRoute] Guid videoId, CancellationToken cancellationToken)
     {
         var shared = await videoUploaderService.GetSasForConvertedVideoAsync(videoId, cancellationToken);
@@ -72,7 +70,7 @@ public class ConverterController : Controller
     }
 
     [HttpPost]
-    [Route(ApiEndpoints.Converter.Upload)]
+    [Route(ConversionRoutes.Upload)]
     public async Task<IActionResult> PublishConvertedVideo([FromRoute] Guid videoId, CancellationToken cancellationToken)
     {
         var newId = await videoUploaderService.UploadConvertedVideoAsync(videoId, cancellationToken);

--- a/src/backend/TB.DanceDance.API/Features/Groups/GroupController.cs
+++ b/src/backend/TB.DanceDance.API/Features/Groups/GroupController.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using TB.DanceDance.API.Contracts.Features.Groups;
 using TB.DanceDance.API.Contracts.Features.Videos;
-using TB.DanceDance.API.Contracts.Responses;
 using TB.DanceDance.API.Extensions;
 using TB.DanceDance.API.Mappers;
 

--- a/src/backend/TB.DanceDance.API/Mappers/ContractMappers.cs
+++ b/src/backend/TB.DanceDance.API/Mappers/ContractMappers.cs
@@ -2,8 +2,6 @@
 using TB.DanceDance.API.Contracts.Features.Events;
 using TB.DanceDance.API.Contracts.Features.Videos;
 using TB.DanceDance.API.Contracts.Models;
-using TB.DanceDance.API.Contracts.Requests;
-using TB.DanceDance.API.Contracts.Responses;
 using TB.DanceDance.API.Extensions;
 
 namespace TB.DanceDance.API.Mappers;

--- a/src/backend/TB.DanceDance.Services.Converter.Deamon/DanceDanceApiClient.cs
+++ b/src/backend/TB.DanceDance.Services.Converter.Deamon/DanceDanceApiClient.cs
@@ -1,8 +1,7 @@
 ﻿using Azure.Storage.Blobs;
 using System.Net.Http.Json;
 using System.Text.Json;
-using TB.DanceDance.API.Contracts.Requests;
-using TB.DanceDance.API.Contracts.Responses;
+using TB.DanceDance.API.Contracts.Features.Conversion;
 using TB.DanceDance.Services.Converter.Deamon.OAuthClient;
 
 namespace TB.DanceDance.Services.Converter.Deamon;

--- a/src/backend/TB.DanceDance.Services.Converter.Deamon/Deamon.cs
+++ b/src/backend/TB.DanceDance.Services.Converter.Deamon/Deamon.cs
@@ -76,7 +76,7 @@ internal sealed class Deamon : BackgroundService
         Log.Information("Getting video information.");
         var info = await converter.GetInfoAsync(inputVideo);
         Log.Information("Updating video informations.");
-        await client.UploadVideoToTransformInformation(new TB.DanceDance.API.Contracts.Requests.UpdateVideoInfoRequest()
+        await client.UploadVideoToTransformInformation(new TB.DanceDance.API.Contracts.Features.Conversion.UpdateVideoInfoRequest()
         {
             Duration = info.Value.Item2,
             RecordedDateTime = info.Value.Item1,

--- a/src/backend/TB.DanceDance.Services.Converter.Deamon/IDanceDanceApiClient.cs
+++ b/src/backend/TB.DanceDance.Services.Converter.Deamon/IDanceDanceApiClient.cs
@@ -1,5 +1,4 @@
-﻿using TB.DanceDance.API.Contracts.Requests;
-using TB.DanceDance.API.Contracts.Responses;
+﻿using TB.DanceDance.API.Contracts.Features.Conversion;
 
 namespace TB.DanceDance.Services.Converter.Deamon;
 

--- a/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/DanceHttpApiClient.cs
+++ b/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/DanceHttpApiClient.cs
@@ -6,8 +6,6 @@ using TB.DanceDance.API.Contracts.Features.Sharing;
 using TB.DanceDance.API.Contracts.Features.Groups;
 using TB.DanceDance.API.Contracts.Features.Videos;
 using TB.DanceDance.API.Contracts.Models;
-using TB.DanceDance.API.Contracts.Requests;
-using TB.DanceDance.API.Contracts.Responses;
 using TB.DanceDance.Mobile.Library.Services.Auth;
 
 namespace TB.DanceDance.Mobile.Library.Services.DanceApi;

--- a/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/IDanceHttpApiClient.cs
+++ b/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/IDanceHttpApiClient.cs
@@ -3,8 +3,6 @@ using TB.DanceDance.API.Contracts.Features.Sharing;
 ﻿using TB.DanceDance.API.Contracts.Features.Groups;
 using TB.DanceDance.API.Contracts.Features.Videos;
 using TB.DanceDance.API.Contracts.Models;
-using TB.DanceDance.API.Contracts.Requests;
-using TB.DanceDance.API.Contracts.Responses;
 
 namespace TB.DanceDance.Mobile.Library.Services.DanceApi;
 

--- a/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/VideoUploader.cs
+++ b/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/VideoUploader.cs
@@ -2,7 +2,6 @@
 using System.Threading.Channels;
 using TB.DanceDance.API.Contracts.Features.Videos;
 using TB.DanceDance.API.Contracts.Models;
-using TB.DanceDance.API.Contracts.Requests;
 using TB.DanceDance.Mobile.Library.Data;
 using TB.DanceDance.Mobile.Library.Data.Models.Storage;
 using TB.DanceDance.Mobile.Library.Services.Network;

--- a/src/mobile/TB.DanceDance.Mobile/PageModels/GetAccessPageModel.cs
+++ b/src/mobile/TB.DanceDance.Mobile/PageModels/GetAccessPageModel.cs
@@ -4,7 +4,6 @@ using Serilog;
 using TB.DanceDance.API.Contracts.Features.AccessManagement;
 using TB.DanceDance.API.Contracts.Features.Videos;
 using TB.DanceDance.API.Contracts.Models;
-using TB.DanceDance.API.Contracts.Requests;
 using TB.DanceDance.Mobile.Library.Services.DanceApi;
 
 namespace TB.DanceDance.Mobile.PageModels;

--- a/src/mobile/TB.DanceDance.Mobile/Pages/Popups/SharingPopupViewModel.cs
+++ b/src/mobile/TB.DanceDance.Mobile/Pages/Popups/SharingPopupViewModel.cs
@@ -3,7 +3,6 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
 using TB.DanceDance.API.Contracts.Features.Sharing;
-using TB.DanceDance.API.Contracts.Responses;
 using TB.DanceDance.Mobile.Library.Services.DanceApi;
 namespace TB.DanceDance.Mobile.Pages.Popups;
 

--- a/src/tests/TB.DanceDance.Mobile.Tests/IntegrationTests/DanceHttpApiClientTests.cs
+++ b/src/tests/TB.DanceDance.Mobile.Tests/IntegrationTests/DanceHttpApiClientTests.cs
@@ -5,8 +5,6 @@ using TB.DanceDance.API.Contracts.Features.Sharing;
 using TB.DanceDance.API.Contracts.Features.Groups;
 using TB.DanceDance.API.Contracts.Features.Videos;
 using TB.DanceDance.API.Contracts.Models;
-using TB.DanceDance.API.Contracts.Requests;
-using TB.DanceDance.API.Contracts.Responses;
 using TB.DanceDance.Mobile.Library.Services.Auth;
 using TB.DanceDance.Mobile.Library.Services.DanceApi;
 using WireMock.RequestBuilders;

--- a/src/tests/TB.DanceDance.Mobile.Tests/IntegrationTests/VideoUploaderTests.cs
+++ b/src/tests/TB.DanceDance.Mobile.Tests/IntegrationTests/VideoUploaderTests.cs
@@ -4,7 +4,6 @@ using NSubstitute;
 using System.Threading.Channels;
 using TB.DanceDance.API.Contracts.Features.Videos;
 using TB.DanceDance.API.Contracts.Models;
-using TB.DanceDance.API.Contracts.Requests;
 using TB.DanceDance.Mobile.Library.Data;
 using TB.DanceDance.Mobile.Library.Data.Models.Storage;
 using TB.DanceDance.Mobile.Library.Services.DanceApi;

--- a/src/tests/TB.DanceDance.Tests/Converter/DanceDanceApiClientTests.cs
+++ b/src/tests/TB.DanceDance.Tests/Converter/DanceDanceApiClientTests.cs
@@ -1,7 +1,6 @@
 ﻿using TB.DanceDance.Services.Converter.Deamon;
 using TB.DanceDance.Services.Converter.Deamon.OAuthClient;
-using TB.DanceDance.API.Contracts.Requests;
-using TB.DanceDance.API.Contracts.Responses;
+using TB.DanceDance.API.Contracts.Features.Conversion;
 using System.Text.Json;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;

--- a/src/tests/TB.DanceDance.Tests/Converter/DeamonTests.cs
+++ b/src/tests/TB.DanceDance.Tests/Converter/DeamonTests.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
-using TB.DanceDance.API.Contracts.Requests;
-using TB.DanceDance.API.Contracts.Responses;
+using TB.DanceDance.API.Contracts.Features.Conversion;
 using TB.DanceDance.Services.Converter.Deamon;
 using TB.DanceDance.Services.Converter.Deamon.FFmpegClient;
 


### PR DESCRIPTION
Co-locates the Video Conversion slice (controller, DTOs, route constants) under `Features/Conversion/` folders. This is the final feature slice per the rollout plan.

## Changes
- `TB.DanceDance.API/Features/Conversion/` — `ConverterController`, new `ConversionRoutes` constants
- `TB.DanceDance.API.Contracts/Features/Conversion/` — `UpdateVideoInfoRequest`, `VideoToTransformResponse`, `GetPublishSasResponse`, `UploadConvertedVideoResponse`
- Converter daemon and its tests updated to reference `Features.Conversion`
- `ApiEndpoints.Converter` block removed (constants live in `ConversionRoutes`)
- `Contracts/Requests/` and `Contracts/Responses/` folders now empty (all DTOs live under `Features/<Name>/`)
- Dangling `using TB.DanceDance.API.Contracts.Requests/Responses;` cleaned up across API mappers, mobile library, MAUI app, and test files

The converter-facing methods on `VideoUploaderService` stay in `Application/Features/Videos/` — the same class also serves the user-facing upload flow, and splitting it would exceed the folder-reorg scope.

> Stacked on top of #76 (Videos slice). Targets `worktree-vsa-videos-pilot`.

## Test plan
- [x] `dotnet build` — API, Application, Domain, Infrastructure, Contracts, Tests, Mobile.Library, Mobile.Tests — clean
- [x] `dotnet build` MAUI Android — clean
- [x] `dotnet test --filter "FullyQualifiedName~Converter"` — 13 passed (1 pre-existing skip)