### PR TITLE
Remove Domain.csproj copy from API Dockerfile

### DIFF
--- a/src/backend/TB.DanceDance.API/Dockerfile
+++ b/src/backend/TB.DanceDance.API/Dockerfile
@@ -10,7 +10,6 @@ ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["backend/TB.DanceDance.API/TB.DanceDance.API.csproj", "backend/TB.DanceDance.API/"]
 COPY ["backend/Application/Application.csproj", "backend/Application/"]
-COPY ["backend/Domain/Domain.csproj", "backend/Domain/"]
 COPY ["backend/Infrastructure/Infrastructure.csproj", "backend/Infrastructure/"]
 COPY ["backend/TB.DanceDance.API.Contracts/TB.DanceDance.API.Contracts.csproj", "backend/TB.DanceDance.API.Contracts/"]
 RUN dotnet restore "backend/TB.DanceDance.API/TB.DanceDance.API.csproj"


### PR DESCRIPTION
## Summary
- PR #79 deleted `src/backend/Domain/Domain.csproj` but the API Dockerfile still tried to `COPY` it. Any cache-cold image build of `tb.dancedance.api` would fail at line 13.
- One-line fix: drop the dead `COPY` line.

## Test plan
- [x] `docker compose -f local_environment.dockercompose.yaml build api` succeeds (verified locally, fresh build, image `f017a85375ad`).
- [x] `docker compose -f local_environment.dockercompose.yaml build converter initializator` still succeed (no Domain references in those Dockerfiles).