### PR TITLE
test(web): add Angular unit test suite and run it in CI

### DIFF
--- a/.github/workflows/pr-gated.yaml
+++ b/.github/workflows/pr-gated.yaml
@@ -33,9 +33,15 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: src/my-dance.web/package-lock.json
       - name: Install frontend dependencies
         working-directory: ./src/my-dance.web
         run: npm ci
+
+      - name: Run frontend unit tests
+        working-directory: ./src/my-dance.web
+        run: npm run test:ci
 
       - name: Build frontend project
         working-directory: ./src/my-dance.web

--- a/src/my-dance.web/package-lock.json
+++ b/src/my-dance.web/package-lock.json
@@ -23,6 +23,7 @@
         "@angular/build": "^22.0.0",
         "@angular/cli": "^22.0.0",
         "@angular/compiler-cli": "^22.0.0",
+        "@vitest/coverage-v8": "^4.1.8",
         "jsdom": "^28.0.0",
         "prettier": "^3.8.1",
         "typescript": "~6.0.3",
@@ -1867,6 +1868,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -4525,6 +4536,37 @@
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
+      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.8",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.8",
+        "vitest": "4.1.8"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
@@ -4814,6 +4856,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.3.tgz",
+      "integrity": "sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
@@ -6068,6 +6129,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -6139,6 +6210,13 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
@@ -6390,6 +6468,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jose": {
       "version": "6.2.3",
@@ -6670,6 +6787,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-fetch-happen": {
@@ -8335,6 +8480,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/symbol-tree": {

--- a/src/my-dance.web/package.json
+++ b/src/my-dance.web/package.json
@@ -6,7 +6,9 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "test:ci": "ng test --watch=false",
+    "test:coverage": "ng test --watch=false --coverage"
   },
   "private": true,
   "packageManager": "npm@11.6.4",
@@ -26,6 +28,7 @@
     "@angular/build": "^22.0.0",
     "@angular/cli": "^22.0.0",
     "@angular/compiler-cli": "^22.0.0",
+    "@vitest/coverage-v8": "^4.1.8",
     "jsdom": "^28.0.0",
     "prettier": "^3.8.1",
     "typescript": "~6.0.3",

--- a/src/my-dance.web/src/app/core/anonymous-id.service.spec.ts
+++ b/src/my-dance.web/src/app/core/anonymous-id.service.spec.ts
@@ -1,0 +1,44 @@
+import { AnonymousIdService } from './anonymous-id.service';
+
+const STORAGE_KEY = 'anonymousId';
+
+describe('AnonymousIdService', () => {
+  let service: AnonymousIdService;
+
+  beforeEach(() => {
+    localStorage.clear();
+    service = new AnonymousIdService();
+  });
+
+  it('returns the id already stored under the legacy key', () => {
+    localStorage.setItem(STORAGE_KEY, 'existing-id');
+    expect(service.getId()).toBe('existing-id');
+  });
+
+  it('generates and persists a new id when none exists', () => {
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+
+    const id = service.getId();
+
+    expect(id).toBeTruthy();
+    expect(localStorage.getItem(STORAGE_KEY)).toBe(id);
+  });
+
+  it('returns a stable id across calls (generates only once)', () => {
+    const spy = vi.spyOn(crypto, 'randomUUID');
+
+    const first = service.getId();
+    const second = service.getId();
+
+    expect(first).toBe(second);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('generates a UUID via crypto.randomUUID', () => {
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue(
+      '123e4567-e89b-12d3-a456-426614174000',
+    );
+
+    expect(service.getId()).toBe('123e4567-e89b-12d3-a456-426614174000');
+  });
+});

--- a/src/my-dance.web/src/app/core/api/access.service.spec.ts
+++ b/src/my-dance.web/src/app/core/api/access.service.spec.ts
@@ -1,0 +1,70 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { signal } from '@angular/core';
+
+import { AccessService } from './access.service';
+import { ConfigService } from '../config/config.service';
+
+const BASE = 'https://api.test';
+
+describe('AccessService', () => {
+  let service: AccessService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {
+          provide: ConfigService,
+          useValue: { config: signal({ apiBaseUrl: BASE, authUrl: '', redirectUri: '' }) },
+        },
+      ],
+    });
+    service = TestBed.inject(AccessService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('getAllEventsAndGroups() GETs /api/videos/accesses', () => {
+    service.getAllEventsAndGroups().subscribe();
+    const req = httpMock.expectOne(`${BASE}/api/videos/accesses`);
+    expect(req.request.method).toBe('GET');
+    req.flush({ events: [], groups: [] });
+  });
+
+  it('getMyAccess() GETs /api/videos/accesses/my', () => {
+    service.getMyAccess().subscribe();
+    const req = httpMock.expectOne(`${BASE}/api/videos/accesses/my`);
+    expect(req.request.method).toBe('GET');
+    req.flush({});
+  });
+
+  it('requestAccess() POSTs the request payload', () => {
+    const body = { events: ['e1'], groups: [{ id: 'g1', joinedDate: new Date('2026-01-01') }] };
+    service.requestAccess(body).subscribe();
+    const req = httpMock.expectOne(`${BASE}/api/videos/accesses/request`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(body);
+    req.flush(null);
+  });
+
+  it('listAccessRequests() GETs the pending requests', () => {
+    service.listAccessRequests().subscribe();
+    const req = httpMock.expectOne(`${BASE}/api/videos/accesses/requests`);
+    expect(req.request.method).toBe('GET');
+    req.flush({ accessRequests: [] });
+  });
+
+  it('approveAccessRequest() POSTs the decision', () => {
+    const body = { requestId: 'r1', isGroup: true, isApproved: true };
+    service.approveAccessRequest(body).subscribe();
+    const req = httpMock.expectOne(`${BASE}/api/videos/accesses/requests`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(body);
+    req.flush(null);
+  });
+});

--- a/src/my-dance.web/src/app/core/api/api-client.spec.ts
+++ b/src/my-dance.web/src/app/core/api/api-client.spec.ts
@@ -1,0 +1,115 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { WritableSignal, signal } from '@angular/core';
+
+import { ApiClient } from './api-client';
+import { ConfigService } from '../config/config.service';
+import { AppConfig } from '../config/app-config';
+
+describe('ApiClient', () => {
+  let api: ApiClient;
+  let httpMock: HttpTestingController;
+  let cfg: WritableSignal<AppConfig>;
+
+  beforeEach(() => {
+    cfg = signal<AppConfig>({
+      apiBaseUrl: 'https://api.test',
+      authUrl: 'https://auth.test',
+      redirectUri: 'https://app.test/callback',
+    });
+    TestBed.configureTestingModule({
+      providers: [
+        ApiClient,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: ConfigService, useValue: { config: cfg } },
+      ],
+    });
+    api = TestBed.inject(ApiClient);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  describe('url()', () => {
+    it('joins the base url with a leading-slash path', () => {
+      expect(api.url('/api/videos/my')).toBe('https://api.test/api/videos/my');
+    });
+
+    it('inserts a separator when the path has no leading slash', () => {
+      expect(api.url('api/videos/my')).toBe('https://api.test/api/videos/my');
+    });
+
+    it('strips trailing slashes from the configured base url', () => {
+      cfg.set({ ...cfg(), apiBaseUrl: 'https://api.test///' });
+      expect(api.url('/api/x')).toBe('https://api.test/api/x');
+    });
+
+    it('reflects later config changes', () => {
+      cfg.set({ ...cfg(), apiBaseUrl: 'https://other.test' });
+      expect(api.url('/api/x')).toBe('https://other.test/api/x');
+    });
+  });
+
+  describe('verbs', () => {
+    it('GET hits the resolved url and returns the body', () => {
+      let body: unknown;
+      api.get<{ ok: boolean }>('/api/x').subscribe((b) => (body = b));
+
+      const req = httpMock.expectOne('https://api.test/api/x');
+      expect(req.request.method).toBe('GET');
+      req.flush({ ok: true });
+
+      expect(body).toEqual({ ok: true });
+    });
+
+    it('POST sends the provided body', () => {
+      api.post('/api/x', { a: 1 }).subscribe();
+      const req = httpMock.expectOne('https://api.test/api/x');
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({ a: 1 });
+      req.flush(null);
+    });
+
+    it('POST sends null when no body is given', () => {
+      api.post('/api/x').subscribe();
+      const req = httpMock.expectOne('https://api.test/api/x');
+      expect(req.request.body).toBeNull();
+      req.flush(null);
+    });
+
+    it('PUT sends the provided body', () => {
+      api.put('/api/x', { b: 2 }).subscribe();
+      const req = httpMock.expectOne('https://api.test/api/x');
+      expect(req.request.method).toBe('PUT');
+      expect(req.request.body).toEqual({ b: 2 });
+      req.flush(null);
+    });
+
+    it('PUT sends null when no body is given', () => {
+      api.put('/api/x').subscribe();
+      const req = httpMock.expectOne('https://api.test/api/x');
+      expect(req.request.body).toBeNull();
+      req.flush(null);
+    });
+
+    it('DELETE hits the resolved url', () => {
+      api.delete('/api/x').subscribe();
+      const req = httpMock.expectOne('https://api.test/api/x');
+      expect(req.request.method).toBe('DELETE');
+      req.flush(null);
+    });
+
+    it('forwards request options (params and headers)', () => {
+      api
+        .get('/api/x', { params: { page: 2 }, headers: { 'X-Test': 'yes' } })
+        .subscribe();
+
+      const req = httpMock.expectOne((r) => r.url === 'https://api.test/api/x');
+      expect(req.request.params.get('page')).toBe('2');
+      expect(req.request.headers.get('X-Test')).toBe('yes');
+      req.flush(null);
+    });
+  });
+});

--- a/src/my-dance.web/src/app/core/api/blob-upload.service.spec.ts
+++ b/src/my-dance.web/src/app/core/api/blob-upload.service.spec.ts
@@ -1,0 +1,140 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpEventType, provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+
+import { BlobUploadService } from './blob-upload.service';
+
+const BLOCK_SIZE = 8 * 1024 * 1024;
+const SAS = 'https://blob.test/container/blob?sig=abc';
+
+/** A File whose reported size we can inflate without allocating the bytes. */
+function fakeFile(size: number, type = 'video/mp4'): File {
+  const file = new File([new Uint8Array(1)], 'video.mp4', { type });
+  Object.defineProperty(file, 'size', { value: size });
+  return file;
+}
+
+describe('BlobUploadService', () => {
+  let service: BlobUploadService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [BlobUploadService, provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(BlobUploadService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  describe('single PUT (file at or below the block size)', () => {
+    it('PUTs the whole file with block-blob headers', () => {
+      const file = new File([new Uint8Array(10)], 'small.mp4', { type: 'video/mp4' });
+      service.upload(SAS, file).subscribe();
+
+      const req = httpMock.expectOne(SAS);
+      expect(req.request.method).toBe('PUT');
+      expect(req.request.headers.get('x-ms-blob-type')).toBe('BlockBlob');
+      expect(req.request.headers.get('Content-Type')).toBe('video/mp4');
+      expect(req.request.body).toBe(file);
+      req.flush(null);
+    });
+
+    it('falls back to application/octet-stream when the file has no type', () => {
+      const file = new File([new Uint8Array(10)], 'small', { type: '' });
+      service.upload(SAS, file).subscribe();
+
+      const req = httpMock.expectOne(SAS);
+      expect(req.request.headers.get('Content-Type')).toBe('application/octet-stream');
+      req.flush(null);
+    });
+
+    it('maps upload-progress events to whole-number percentages', () => {
+      const file = new File([new Uint8Array(10)], 'small.mp4', { type: 'video/mp4' });
+      const emissions: number[] = [];
+      service.upload(SAS, file).subscribe((p) => emissions.push(p));
+
+      const req = httpMock.expectOne(SAS);
+      req.event({ type: HttpEventType.UploadProgress, loaded: 5, total: 10 });
+      req.event({ type: HttpEventType.UploadProgress, loaded: 10, total: 10 });
+      req.flush(null);
+
+      expect(emissions).toEqual([50, 100]);
+    });
+
+    it('ignores progress events that carry no total', () => {
+      const file = new File([new Uint8Array(10)], 'small.mp4', { type: 'video/mp4' });
+      const emissions: number[] = [];
+      service.upload(SAS, file).subscribe((p) => emissions.push(p));
+
+      const req = httpMock.expectOne(SAS);
+      req.event({ type: HttpEventType.UploadProgress, loaded: 5, total: 0 });
+      req.flush(null);
+
+      expect(emissions).toEqual([]);
+    });
+
+    it('uses a single PUT for a file of exactly the block size', () => {
+      const file = fakeFile(BLOCK_SIZE);
+      service.upload(SAS, file).subscribe();
+
+      // No &comp=block query — the request targets the bare SAS url.
+      const req = httpMock.expectOne(SAS);
+      expect(req.request.method).toBe('PUT');
+      req.flush(null);
+    });
+  });
+
+  describe('block upload (file above the block size)', () => {
+    it('uploads each block then commits a block list, completing at 100', () => {
+      const file = fakeFile(BLOCK_SIZE + 100);
+      const id0 = btoa('block-00000000');
+      const id1 = btoa('block-00000001');
+
+      const emissions: number[] = [];
+      let completed = false;
+      service.upload(SAS, file).subscribe({
+        next: (p) => emissions.push(p),
+        complete: () => (completed = true),
+      });
+
+      // concat() serializes the requests: only one is open at a time.
+      const block0 = httpMock.expectOne((r) => r.url.includes('comp=block'));
+      expect(block0.request.method).toBe('PUT');
+      expect(block0.request.url).toContain(`blockid=${encodeURIComponent(id0)}`);
+      block0.event({ type: HttpEventType.UploadProgress, loaded: 4_000_000, total: BLOCK_SIZE + 100 });
+      block0.flush(null);
+
+      const block1 = httpMock.expectOne((r) => r.url.includes('comp=block'));
+      expect(block1.request.url).toContain(`blockid=${encodeURIComponent(id1)}`);
+      block1.flush(null);
+
+      const commit = httpMock.expectOne((r) => r.url.includes('comp=blocklist'));
+      expect(commit.request.method).toBe('PUT');
+      expect(commit.request.headers.get('Content-Type')).toBe('application/xml');
+      expect(commit.request.body).toContain(`<Latest>${id0}</Latest>`);
+      expect(commit.request.body).toContain(`<Latest>${id1}</Latest>`);
+      commit.flush(null);
+
+      expect(completed).toBe(true);
+      expect(emissions.every((p) => p >= 0 && p <= 100)).toBe(true);
+      expect(emissions.at(-1)).toBe(100);
+    });
+
+    it('uses stable, equal-length, base64 block ids', () => {
+      const file = fakeFile(BLOCK_SIZE * 2 + 1);
+      service.upload(SAS, file).subscribe();
+
+      const ids = [btoa('block-00000000'), btoa('block-00000001'), btoa('block-00000002')];
+      // All ids decode to the same length before encoding (required by Azure).
+      expect(new Set(ids.map((id) => id.length)).size).toBe(1);
+
+      for (const id of ids) {
+        const req = httpMock.expectOne((r) => r.url.includes(`blockid=${encodeURIComponent(id)}`));
+        req.flush(null);
+      }
+      httpMock.expectOne((r) => r.url.includes('comp=blocklist')).flush(null);
+    });
+  });
+});

--- a/src/my-dance.web/src/app/core/api/comments.service.spec.ts
+++ b/src/my-dance.web/src/app/core/api/comments.service.spec.ts
@@ -1,0 +1,96 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { signal } from '@angular/core';
+
+import { CommentsService } from './comments.service';
+import { ConfigService } from '../config/config.service';
+import { AnonymousIdService } from '../anonymous-id.service';
+
+const BASE = 'https://api.test';
+const ANON_ID = 'anon-123';
+
+describe('CommentsService', () => {
+  let service: CommentsService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {
+          provide: ConfigService,
+          useValue: { config: signal({ apiBaseUrl: BASE, authUrl: '', redirectUri: '' }) },
+        },
+        { provide: AnonymousIdService, useValue: { getId: () => ANON_ID } },
+      ],
+    });
+    service = TestBed.inject(CommentsService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('getCommentsForVideo() GETs the authenticated video comments', () => {
+    service.getCommentsForVideo('vid/1').subscribe();
+    const req = httpMock.expectOne(`${BASE}/api/comments/video/vid%2F1`);
+    expect(req.request.method).toBe('GET');
+    req.flush({ comments: [] });
+  });
+
+  it('getCommentsByLink() GETs link comments with the AnonymousId header', () => {
+    service.getCommentsByLink('link1').subscribe();
+    const req = httpMock.expectOne(`${BASE}/api/share/link1/comments`);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.headers.get('AnonymousId')).toBe(ANON_ID);
+    req.flush({ comments: [] });
+  });
+
+  it('addCommentByLink() POSTs the comment body', () => {
+    const body = { content: 'Nice!', authorName: 'Guest', anonymousId: ANON_ID };
+    service.addCommentByLink('link1', body).subscribe();
+    const req = httpMock.expectOne(`${BASE}/api/share/link1/comments`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(body);
+    req.flush({ id: 'c1' });
+  });
+
+  it('updateComment() PUTs the content merged with the anonymous id', () => {
+    service.updateComment('c1', { content: 'edited' }).subscribe();
+    const req = httpMock.expectOne(`${BASE}/api/comments/c1`);
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toEqual({ content: 'edited', anonymousId: ANON_ID });
+    req.flush(null);
+  });
+
+  it('deleteComment() DELETEs with the AnonymousId header', () => {
+    service.deleteComment('c1').subscribe();
+    const req = httpMock.expectOne(`${BASE}/api/comments/c1`);
+    expect(req.request.method).toBe('DELETE');
+    expect(req.request.headers.get('AnonymousId')).toBe(ANON_ID);
+    req.flush(null);
+  });
+
+  it('hideComment() PUTs the hide endpoint', () => {
+    service.hideComment('c1').subscribe();
+    const req = httpMock.expectOne(`${BASE}/api/comments/c1/hide`);
+    expect(req.request.method).toBe('PUT');
+    req.flush(null);
+  });
+
+  it('unhideComment() PUTs the unhide endpoint', () => {
+    service.unhideComment('c1').subscribe();
+    const req = httpMock.expectOne(`${BASE}/api/comments/c1/unhide`);
+    expect(req.request.method).toBe('PUT');
+    req.flush(null);
+  });
+
+  it('reportComment() POSTs the reason to the report endpoint', () => {
+    service.reportComment('c1', { reason: 'spam' }).subscribe();
+    const req = httpMock.expectOne(`${BASE}/api/comments/c1/report`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ reason: 'spam' });
+    req.flush(null);
+  });
+});

--- a/src/my-dance.web/src/app/core/api/events.service.spec.ts
+++ b/src/my-dance.web/src/app/core/api/events.service.spec.ts
@@ -1,0 +1,47 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { signal } from '@angular/core';
+
+import { EventsService } from './events.service';
+import { ConfigService } from '../config/config.service';
+
+const BASE = 'https://api.test';
+
+describe('EventsService', () => {
+  let service: EventsService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {
+          provide: ConfigService,
+          useValue: { config: signal({ apiBaseUrl: BASE, authUrl: '', redirectUri: '' }) },
+        },
+      ],
+    });
+    service = TestBed.inject(EventsService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('createEvent() POSTs the new event', () => {
+    const body = { event: { name: 'Gala', date: new Date('2026-01-01') } };
+    service.createEvent(body).subscribe();
+    const req = httpMock.expectOne(`${BASE}/api/events`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(body);
+    req.flush({ id: 'e1' });
+  });
+
+  it('getEventVideos() GETs the url-encoded event videos', () => {
+    service.getEventVideos('e/1').subscribe();
+    const req = httpMock.expectOne(`${BASE}/api/events/e%2F1/videos`);
+    expect(req.request.method).toBe('GET');
+    req.flush({ videos: [] });
+  });
+});

--- a/src/my-dance.web/src/app/core/api/groups.service.spec.ts
+++ b/src/my-dance.web/src/app/core/api/groups.service.spec.ts
@@ -1,0 +1,45 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { signal } from '@angular/core';
+
+import { GroupsService } from './groups.service';
+import { ConfigService } from '../config/config.service';
+
+const BASE = 'https://api.test';
+
+describe('GroupsService', () => {
+  let service: GroupsService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {
+          provide: ConfigService,
+          useValue: { config: signal({ apiBaseUrl: BASE, authUrl: '', redirectUri: '' }) },
+        },
+      ],
+    });
+    service = TestBed.inject(GroupsService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('getGroupVideos() GETs /api/groups/videos', () => {
+    service.getGroupVideos().subscribe();
+    const req = httpMock.expectOne(`${BASE}/api/groups/videos`);
+    expect(req.request.method).toBe('GET');
+    req.flush({ videos: [] });
+  });
+
+  it('getVideosForGroup() GETs the url-encoded group videos', () => {
+    service.getVideosForGroup('g/1').subscribe();
+    const req = httpMock.expectOne(`${BASE}/api/groups/g%2F1/videos`);
+    expect(req.request.method).toBe('GET');
+    req.flush({ videos: [] });
+  });
+});

--- a/src/my-dance.web/src/app/core/api/sharing.service.spec.ts
+++ b/src/my-dance.web/src/app/core/api/sharing.service.spec.ts
@@ -1,0 +1,69 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { signal } from '@angular/core';
+
+import { SharingService } from './sharing.service';
+import { ConfigService } from '../config/config.service';
+
+const BASE = 'https://api.test';
+
+describe('SharingService', () => {
+  let service: SharingService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {
+          provide: ConfigService,
+          useValue: { config: signal({ apiBaseUrl: BASE, authUrl: '', redirectUri: '' }) },
+        },
+      ],
+    });
+    service = TestBed.inject(SharingService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('createSharedLink() POSTs the request to the video share endpoint', () => {
+    const body = { expirationDays: 7, allowComments: true, allowAnonymousComments: false };
+    service.createSharedLink('vid1', body).subscribe();
+    const req = httpMock.expectOne(`${BASE}/api/videos/vid1/share`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(body);
+    req.flush({ linkId: 'l1' });
+  });
+
+  it('getMySharedLinks() GETs /api/share/my', () => {
+    service.getMySharedLinks().subscribe();
+    const req = httpMock.expectOne(`${BASE}/api/share/my`);
+    expect(req.request.method).toBe('GET');
+    req.flush({ links: [] });
+  });
+
+  it('getSharedVideo() GETs the url-encoded link id', () => {
+    service.getSharedVideo('a/b').subscribe();
+    const req = httpMock.expectOne(`${BASE}/api/share/a%2Fb`);
+    expect(req.request.method).toBe('GET');
+    req.flush({});
+  });
+
+  it('revokeSharedLink() DELETEs the link', () => {
+    service.revokeSharedLink('l1').subscribe();
+    const req = httpMock.expectOne(`${BASE}/api/share/l1`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush(null);
+  });
+
+  it('sharedStreamUrl() builds an absolute, link-scoped stream url', () => {
+    expect(service.sharedStreamUrl('l1')).toBe(`${BASE}/api/share/l1/stream`);
+  });
+
+  it('sharedStreamUrl() url-encodes the link id', () => {
+    expect(service.sharedStreamUrl('a/b')).toBe(`${BASE}/api/share/a%2Fb/stream`);
+  });
+});

--- a/src/my-dance.web/src/app/core/api/upload.service.spec.ts
+++ b/src/my-dance.web/src/app/core/api/upload.service.spec.ts
@@ -1,0 +1,57 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { signal } from '@angular/core';
+
+import { UploadService } from './upload.service';
+import { ConfigService } from '../config/config.service';
+import { ProduceUploadUrlRequest, SharingWithType } from './api-models';
+
+const BASE = 'https://api.test';
+
+describe('UploadService', () => {
+  let service: UploadService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {
+          provide: ConfigService,
+          useValue: { config: signal({ apiBaseUrl: BASE, authUrl: '', redirectUri: '' }) },
+        },
+      ],
+    });
+    service = TestBed.inject(UploadService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('produceUploadUrl() POSTs the upload request', () => {
+    const body: ProduceUploadUrlRequest = {
+      nameOfVideo: 'Lesson',
+      fileName: 'lesson.mp4',
+      sharedWith: 'g1',
+      sharingWithType: SharingWithType.Group,
+    };
+    let response: unknown;
+    service.produceUploadUrl(body).subscribe((r) => (response = r));
+
+    const req = httpMock.expectOne(`${BASE}/api/videos/upload`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(body);
+    req.flush({ sas: 'https://blob/sas', videoId: 'v1' });
+
+    expect(response).toEqual({ sas: 'https://blob/sas', videoId: 'v1' });
+  });
+
+  it('refreshUploadUrl() GETs a fresh SAS for the url-encoded video id', () => {
+    service.refreshUploadUrl('v/1').subscribe();
+    const req = httpMock.expectOne(`${BASE}/api/videos/upload/v%2F1`);
+    expect(req.request.method).toBe('GET');
+    req.flush({ sas: 'https://blob/sas2' });
+  });
+});

--- a/src/my-dance.web/src/app/core/api/videos.service.spec.ts
+++ b/src/my-dance.web/src/app/core/api/videos.service.spec.ts
@@ -1,0 +1,83 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { signal } from '@angular/core';
+
+import { VideosService } from './videos.service';
+import { ConfigService } from '../config/config.service';
+
+const BASE = 'https://api.test';
+
+describe('VideosService', () => {
+  let service: VideosService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {
+          provide: ConfigService,
+          useValue: { config: signal({ apiBaseUrl: BASE, authUrl: '', redirectUri: '' }) },
+        },
+      ],
+    });
+    service = TestBed.inject(VideosService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('getMyVideos() GETs /api/videos/my', () => {
+    let response: unknown;
+    service.getMyVideos().subscribe((r) => (response = r));
+
+    const req = httpMock.expectOne(`${BASE}/api/videos/my`);
+    expect(req.request.method).toBe('GET');
+    req.flush({ videoInformation: [{ videoId: '1' }] });
+
+    expect(response).toEqual({ videoInformation: [{ videoId: '1' }] });
+  });
+
+  it('getVideo() GETs the url-encoded blob id', () => {
+    service.getVideo('a/b').subscribe();
+    const req = httpMock.expectOne(`${BASE}/api/videos/a%2Fb`);
+    expect(req.request.method).toBe('GET');
+    req.flush({});
+  });
+
+  it('renameVideo() POSTs the new name to the rename endpoint', () => {
+    service.renameVideo('vid 1', { newName: 'Cha-cha' }).subscribe();
+    const req = httpMock.expectOne(`${BASE}/api/videos/vid%201/rename`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ newName: 'Cha-cha' });
+    req.flush(null);
+  });
+
+  it('updateCommentSettings() POSTs the visibility to the comment-settings endpoint', () => {
+    service.updateCommentSettings('vid1', { commentVisibility: 2 }).subscribe();
+    const req = httpMock.expectOne(`${BASE}/api/videos/vid1/comment-settings`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ commentVisibility: 2 });
+    req.flush(null);
+  });
+
+  describe('streamUrl()', () => {
+    it('builds an absolute stream url carrying the token as a query param', () => {
+      expect(service.streamUrl('blob1', 'abc.def')).toBe(
+        `${BASE}/api/videos/blob1/stream?token=abc.def`,
+      );
+    });
+
+    it('url-encodes the blob id', () => {
+      expect(service.streamUrl('a/b', 'tok')).toBe(`${BASE}/api/videos/a%2Fb/stream?token=tok`);
+    });
+
+    it('encodes a token with reserved characters', () => {
+      const url = service.streamUrl('blob1', 'a b&c');
+      expect(url.startsWith(`${BASE}/api/videos/blob1/stream?token=`)).toBe(true);
+      expect(url).not.toContain('a b&c');
+    });
+  });
+});

--- a/src/my-dance.web/src/app/core/auth/auth.guard.spec.ts
+++ b/src/my-dance.web/src/app/core/auth/auth.guard.spec.ts
@@ -1,0 +1,60 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { signal } from '@angular/core';
+
+import { adminGuard, authGuard } from './auth.guard';
+import { AuthService } from './auth.service';
+
+function runGuard(guard: typeof authGuard, url: string) {
+  const state = { url } as RouterStateSnapshot;
+  const route = {} as ActivatedRouteSnapshot;
+  return TestBed.runInInjectionContext(() => guard(route, state));
+}
+
+describe('authGuard', () => {
+  const authed = signal(false);
+  const login = vi.fn();
+
+  beforeEach(() => {
+    authed.set(false);
+    login.mockClear();
+    TestBed.configureTestingModule({
+      providers: [{ provide: AuthService, useValue: { isAuthenticated: authed, login } }],
+    });
+  });
+
+  it('allows authenticated users through without logging in', () => {
+    authed.set(true);
+
+    expect(runGuard(authGuard, '/videos')).toBe(true);
+    expect(login).not.toHaveBeenCalled();
+  });
+
+  it('blocks anonymous users and starts the login flow with the requested url', () => {
+    expect(runGuard(authGuard, '/videos/my')).toBe(false);
+    expect(login).toHaveBeenCalledWith('/videos/my');
+  });
+});
+
+describe('adminGuard', () => {
+  const authed = signal(false);
+  const login = vi.fn();
+
+  beforeEach(() => {
+    authed.set(false);
+    login.mockClear();
+    TestBed.configureTestingModule({
+      providers: [{ provide: AuthService, useValue: { isAuthenticated: authed, login } }],
+    });
+  });
+
+  it('delegates to the auth check (allows authenticated users for now)', () => {
+    authed.set(true);
+    expect(runGuard(adminGuard, '/access/requestedaccesses')).toBe(true);
+  });
+
+  it('blocks anonymous users and remembers the requested url', () => {
+    expect(runGuard(adminGuard, '/access/requestedaccesses')).toBe(false);
+    expect(login).toHaveBeenCalledWith('/access/requestedaccesses');
+  });
+});

--- a/src/my-dance.web/src/app/core/auth/auth.service.spec.ts
+++ b/src/my-dance.web/src/app/core/auth/auth.service.spec.ts
@@ -1,0 +1,97 @@
+import { TestBed } from '@angular/core/testing';
+import { OidcSecurityService } from 'angular-auth-oidc-client';
+import { BehaviorSubject, of } from 'rxjs';
+
+import { AuthService } from './auth.service';
+
+const RETURN_URL_KEY = 'auth.returnUrl';
+
+function createOidcMock() {
+  return {
+    isAuthenticated$: new BehaviorSubject<{ isAuthenticated: boolean; allConfigsAuthenticated: unknown[] }>(
+      { isAuthenticated: false, allConfigsAuthenticated: [] },
+    ),
+    userData$: new BehaviorSubject<{ userData: unknown; allUserData: unknown[] }>({
+      userData: null,
+      allUserData: [],
+    }),
+    checkAuth: vi.fn(() => of({ isAuthenticated: true })),
+    authorize: vi.fn(),
+    logoff: vi.fn(() => of(null)),
+    getAccessToken: vi.fn(() => of('access-token')),
+  };
+}
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let oidc: ReturnType<typeof createOidcMock>;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    oidc = createOidcMock();
+    TestBed.configureTestingModule({
+      providers: [AuthService, { provide: OidcSecurityService, useValue: oidc }],
+    });
+    service = TestBed.inject(AuthService);
+  });
+
+  describe('reactive state', () => {
+    it('starts unauthenticated with no user data', () => {
+      expect(service.isAuthenticated()).toBe(false);
+      expect(service.userData()).toBeNull();
+    });
+
+    it('reflects the OIDC authentication stream', () => {
+      oidc.isAuthenticated$.next({ isAuthenticated: true, allConfigsAuthenticated: [] });
+      expect(service.isAuthenticated()).toBe(true);
+    });
+
+    it('reflects the OIDC user-data stream', () => {
+      oidc.userData$.next({ userData: { name: 'Ada' }, allUserData: [] });
+      expect(service.userData()).toEqual({ name: 'Ada' });
+    });
+  });
+
+  describe('actions', () => {
+    it('checkAuth() delegates to the OIDC service', () => {
+      service.checkAuth().subscribe();
+      expect(oidc.checkAuth).toHaveBeenCalledTimes(1);
+    });
+
+    it('login() stores the return url and starts the flow', () => {
+      service.login('/videos/my');
+      expect(sessionStorage.getItem(RETURN_URL_KEY)).toBe('/videos/my');
+      expect(oidc.authorize).toHaveBeenCalledTimes(1);
+    });
+
+    it('login() without a return url does not write session storage', () => {
+      service.login();
+      expect(sessionStorage.getItem(RETURN_URL_KEY)).toBeNull();
+      expect(oidc.authorize).toHaveBeenCalledTimes(1);
+    });
+
+    it('logout() delegates to logoff()', () => {
+      service.logout().subscribe();
+      expect(oidc.logoff).toHaveBeenCalledTimes(1);
+    });
+
+    it('getAccessToken() delegates to the OIDC service', () => {
+      let token: string | undefined;
+      service.getAccessToken().subscribe((t) => (token = t));
+      expect(token).toBe('access-token');
+    });
+  });
+
+  describe('consumeReturnUrl', () => {
+    it('reads and clears the stored return url', () => {
+      sessionStorage.setItem(RETURN_URL_KEY, '/events');
+
+      expect(service.consumeReturnUrl()).toBe('/events');
+      expect(sessionStorage.getItem(RETURN_URL_KEY)).toBeNull();
+    });
+
+    it('returns null when nothing is stored', () => {
+      expect(service.consumeReturnUrl()).toBeNull();
+    });
+  });
+});

--- a/src/my-dance.web/src/app/core/config/config.service.spec.ts
+++ b/src/my-dance.web/src/app/core/config/config.service.spec.ts
@@ -1,0 +1,95 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+
+import { ConfigService } from './config.service';
+import { DEFAULT_CONFIG } from './app-config';
+
+describe('ConfigService', () => {
+  let service: ConfigService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ConfigService, provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(ConfigService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('exposes the defaults before load() completes', () => {
+    expect(service.config()).toEqual(DEFAULT_CONFIG);
+  });
+
+  it('fetches config.json and exposes the resolved values', () => {
+    service.load().subscribe();
+
+    const req = httpMock.expectOne('config.json');
+    expect(req.request.method).toBe('GET');
+    req.flush({
+      apiBaseUrl: 'https://api.example.com',
+      authUrl: 'https://auth.example.com',
+      redirectUri: 'https://app.example.com/callback',
+    });
+
+    expect(service.config()).toEqual({
+      apiBaseUrl: 'https://api.example.com',
+      authUrl: 'https://auth.example.com',
+      redirectUri: 'https://app.example.com/callback',
+    });
+  });
+
+  it('trims surrounding whitespace on every value', () => {
+    service.load().subscribe();
+    httpMock.expectOne('config.json').flush({
+      apiBaseUrl: '  https://api.example.com  ',
+      authUrl: '\thttps://auth.example.com\n',
+      redirectUri: ' https://app.example.com/callback ',
+    });
+
+    expect(service.config()).toEqual({
+      apiBaseUrl: 'https://api.example.com',
+      authUrl: 'https://auth.example.com',
+      redirectUri: 'https://app.example.com/callback',
+    });
+  });
+
+  it('falls back to defaults for blank apiBaseUrl / authUrl', () => {
+    service.load().subscribe();
+    httpMock.expectOne('config.json').flush({ apiBaseUrl: '   ', authUrl: '' });
+
+    const config = service.config();
+    expect(config.apiBaseUrl).toBe(DEFAULT_CONFIG.apiBaseUrl);
+    expect(config.authUrl).toBe(DEFAULT_CONFIG.authUrl);
+  });
+
+  it('derives redirectUri from the window origin when blank', () => {
+    service.load().subscribe();
+    httpMock.expectOne('config.json').flush({ redirectUri: '   ' });
+
+    expect(service.config().redirectUri).toBe(`${window.location.origin}/callback`);
+  });
+
+  it('falls back to the full default config on HTTP error', () => {
+    let resolved = undefined as unknown;
+    service.load().subscribe((c) => (resolved = c));
+
+    httpMock.expectOne('config.json').flush('boom', { status: 500, statusText: 'Server Error' });
+
+    expect(resolved).toEqual(DEFAULT_CONFIG);
+    expect(service.config()).toEqual(DEFAULT_CONFIG);
+  });
+
+  it('fetches config.json only once across repeated load() calls', () => {
+    service.load().subscribe();
+    service.load().subscribe();
+
+    // A single matching request proves the shared/cached observable.
+    httpMock.expectOne('config.json').flush({ apiBaseUrl: 'https://api.example.com' });
+
+    service.load().subscribe();
+    httpMock.expectNone('config.json');
+  });
+});

--- a/src/my-dance.web/src/app/features/access/access-requests.spec.ts
+++ b/src/my-dance.web/src/app/features/access/access-requests.spec.ts
@@ -99,5 +99,15 @@ describe('AccessRequests', () => {
 
       expect(access.approveAccessRequest).toHaveBeenCalledTimes(1);
     });
+
+    it('clears the processing flag when the decision fails', () => {
+      const approveAccessRequest = vi.fn(() => throwError(() => new Error('x')));
+      const { component, access } = createFixture({ approveAccessRequest });
+
+      component.decide({ requestId: 'r1', isGroup: true }, true);
+
+      expect(component.processingId()).toBeNull();
+      expect(access.listAccessRequests).toHaveBeenCalledTimes(1); // no reload on failure
+    });
   });
 });

--- a/src/my-dance.web/src/app/features/access/access-requests.spec.ts
+++ b/src/my-dance.web/src/app/features/access/access-requests.spec.ts
@@ -1,0 +1,103 @@
+import { TestBed } from '@angular/core/testing';
+import { Subject, of, throwError } from 'rxjs';
+
+import { AccessRequests } from './access-requests';
+import { AccessService } from '../../core/api/access.service';
+import { RequestedAccessModel } from '../../core/api/api-models';
+
+function createFixture(overrides: {
+  listAccessRequests?: ReturnType<typeof vi.fn>;
+  approveAccessRequest?: ReturnType<typeof vi.fn>;
+}) {
+  const access = {
+    listAccessRequests:
+      overrides.listAccessRequests ??
+      vi.fn(() => of({ accessRequests: [{ requestId: 'r1', name: 'Salsa', isGroup: true }] })),
+    approveAccessRequest: overrides.approveAccessRequest ?? vi.fn(() => of(void 0)),
+  };
+
+  TestBed.configureTestingModule({
+    imports: [AccessRequests],
+    providers: [{ provide: AccessService, useValue: access }],
+  });
+
+  const fixture = TestBed.createComponent(AccessRequests);
+  fixture.detectChanges();
+  return { fixture, access, component: fixture.componentInstance };
+}
+
+describe('AccessRequests', () => {
+  it('loads pending requests', () => {
+    const { component } = createFixture({});
+    expect(component.loading()).toBe(false);
+    expect(component.requests()).toHaveLength(1);
+  });
+
+  it('enters the failed state on error', () => {
+    const { component } = createFixture({ listAccessRequests: vi.fn(() => throwError(() => new Error('x'))) });
+    expect(component.failed()).toBe(true);
+  });
+
+  describe('requestorName', () => {
+    it('joins first and last name', () => {
+      const { component } = createFixture({});
+      const req: RequestedAccessModel = { requestorFirstName: 'Ada', requestorLastName: 'Lovelace' };
+      expect(component.requestorName(req)).toBe('Ada Lovelace');
+    });
+
+    it('uses whichever name part is present', () => {
+      const { component } = createFixture({});
+      expect(component.requestorName({ requestorFirstName: 'Ada' })).toBe('Ada');
+    });
+
+    it('falls back to "Someone" when no name is present', () => {
+      const { component } = createFixture({});
+      expect(component.requestorName({})).toBe('Someone');
+    });
+  });
+
+  describe('decide', () => {
+    it('approves a request then reloads the list', () => {
+      const approveAccessRequest = vi.fn(() => of(void 0));
+      const { component, access } = createFixture({ approveAccessRequest });
+
+      component.decide({ requestId: 'r1', isGroup: true }, true);
+
+      expect(access.approveAccessRequest).toHaveBeenCalledWith({
+        requestId: 'r1',
+        isGroup: true,
+        isApproved: true,
+      });
+      expect(component.processingId()).toBeNull();
+      expect(access.listAccessRequests).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects a request with isApproved=false', () => {
+      const approveAccessRequest = vi.fn(() => of(void 0));
+      const { component } = createFixture({ approveAccessRequest });
+      component.decide({ requestId: 'r1', isGroup: false }, false);
+      expect(approveAccessRequest).toHaveBeenCalledWith({
+        requestId: 'r1',
+        isGroup: false,
+        isApproved: false,
+      });
+    });
+
+    it('ignores a request without an id', () => {
+      const { component, access } = createFixture({});
+      component.decide({}, true);
+      expect(access.approveAccessRequest).not.toHaveBeenCalled();
+    });
+
+    it('ignores a decision while another is in flight', () => {
+      // A never-completing observable keeps processingId set.
+      const approveAccessRequest = vi.fn(() => new Subject<void>());
+      const { component, access } = createFixture({ approveAccessRequest });
+
+      component.decide({ requestId: 'r1', isGroup: true }, true);
+      component.decide({ requestId: 'r2', isGroup: true }, true);
+
+      expect(access.approveAccessRequest).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/my-dance.web/src/app/features/access/request-access.spec.ts
+++ b/src/my-dance.web/src/app/features/access/request-access.spec.ts
@@ -115,5 +115,18 @@ describe('RequestAccess', () => {
       expect(component.checkedGroups().size).toBe(0);
       expect(access.getMyAccess).toHaveBeenCalledTimes(2);
     });
+
+    it('clears the submitting flag when the request fails', () => {
+      const { component, access } = createFixture({
+        requestAccess: vi.fn(() => throwError(() => new Error('x'))),
+      });
+      component.toggleEvent('e1');
+      component.submit();
+
+      expect(component.submitting()).toBe(false);
+      // Selection is preserved so the user can retry.
+      expect(component.checkedEvents().has('e1')).toBe(true);
+      expect(access.getMyAccess).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/my-dance.web/src/app/features/access/request-access.spec.ts
+++ b/src/my-dance.web/src/app/features/access/request-access.spec.ts
@@ -1,0 +1,119 @@
+import { TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+
+import { RequestAccess } from './request-access';
+import { AccessService } from '../../core/api/access.service';
+import { GetUserAccessResponse } from '../../core/api/api-models';
+
+const DATE = new Date(2026, 0, 1);
+const FULL_ACCESS: GetUserAccessResponse = {
+  assigned: {
+    groups: [{ id: 'ga', name: 'Assigned group' }],
+    events: [{ id: 'ea', name: 'Assigned event', date: DATE }],
+  },
+  available: {
+    groups: [{ id: 'g1', name: 'Salsa' }],
+    events: [{ id: 'e1', name: 'Gala', date: DATE }],
+  },
+  pending: { groups: ['gp'], events: ['ep1', 'ep2'] },
+};
+
+function createFixture(overrides: {
+  getMyAccess?: ReturnType<typeof vi.fn>;
+  requestAccess?: ReturnType<typeof vi.fn>;
+}) {
+  const access = {
+    getMyAccess: overrides.getMyAccess ?? vi.fn(() => of(FULL_ACCESS)),
+    requestAccess: overrides.requestAccess ?? vi.fn(() => of(void 0)),
+  };
+
+  TestBed.configureTestingModule({
+    imports: [RequestAccess],
+    providers: [{ provide: AccessService, useValue: access }],
+  });
+
+  const fixture = TestBed.createComponent(RequestAccess);
+  fixture.detectChanges();
+  return { fixture, access, component: fixture.componentInstance };
+}
+
+describe('RequestAccess', () => {
+  it('splits assigned, available, and pending access on load', () => {
+    const { component } = createFixture({});
+    expect(component.assignedGroups()).toHaveLength(1);
+    expect(component.availableGroups()).toHaveLength(1);
+    expect(component.availableEvents()).toHaveLength(1);
+    expect(component.pendingCount()).toBe(3); // 1 group + 2 events
+    expect(component.loading()).toBe(false);
+  });
+
+  it('enters the failed state on error', () => {
+    const { component } = createFixture({ getMyAccess: vi.fn(() => throwError(() => new Error('x'))) });
+    expect(component.failed()).toBe(true);
+  });
+
+  describe('selection', () => {
+    it('toggles an event on and off', () => {
+      const { component } = createFixture({});
+      component.toggleEvent('e1');
+      expect(component.checkedEvents().has('e1')).toBe(true);
+      component.toggleEvent('e1');
+      expect(component.checkedEvents().has('e1')).toBe(false);
+    });
+
+    it('ignores a toggle with no id', () => {
+      const { component } = createFixture({});
+      component.toggleEvent(undefined);
+      expect(component.checkedEvents().size).toBe(0);
+    });
+
+    it('defaults a group join date to today when first checked', () => {
+      const { component } = createFixture({});
+      component.toggleGroup('g1');
+      expect(component.checkedGroups().has('g1')).toBe(true);
+      expect(component.groupDates()['g1']).toBe(component.today);
+    });
+
+    it('lets a group join date be overridden', () => {
+      const { component } = createFixture({});
+      component.toggleGroup('g1');
+      component.setGroupDate('g1', '2026-01-15');
+      expect(component.groupDates()['g1']).toBe('2026-01-15');
+    });
+
+    it('drives canSubmit from the current selection', () => {
+      const { component } = createFixture({});
+      expect(component.canSubmit()).toBe(false);
+      component.toggleEvent('e1');
+      expect(component.canSubmit()).toBe(true);
+    });
+  });
+
+  describe('submit', () => {
+    it('does nothing without a selection', () => {
+      const { component, access } = createFixture({});
+      component.submit();
+      expect(access.requestAccess).not.toHaveBeenCalled();
+    });
+
+    it('builds the request payload from the selection and reloads', () => {
+      const requestAccess = vi.fn(() => of(void 0));
+      const { component, access } = createFixture({ requestAccess });
+
+      component.toggleEvent('e1');
+      component.toggleGroup('g1');
+      component.setGroupDate('g1', '2026-03-01');
+      component.submit();
+
+      expect(access.requestAccess).toHaveBeenCalledWith({
+        events: ['e1'],
+        groups: [{ id: 'g1', joinedDate: new Date('2026-03-01') }],
+      });
+      expect(component.submitting()).toBe(false);
+      // Reload clears the selection.
+      expect(component.checkedEvents().size).toBe(0);
+      expect(component.checkedGroups().size).toBe(0);
+      expect(access.getMyAccess).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/my-dance.web/src/app/features/auth/callback.spec.ts
+++ b/src/my-dance.web/src/app/features/auth/callback.spec.ts
@@ -1,0 +1,57 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { signal } from '@angular/core';
+
+import { Callback } from './callback';
+import { AuthService } from '../../core/auth/auth.service';
+
+function setup(opts: { authed: boolean; returnUrl?: string | null }) {
+  const auth = {
+    isAuthenticated: signal(opts.authed),
+    consumeReturnUrl: vi.fn(() => opts.returnUrl ?? null),
+    login: vi.fn(),
+  };
+  const router = { navigateByUrl: vi.fn() };
+
+  TestBed.configureTestingModule({
+    imports: [Callback],
+    providers: [
+      { provide: AuthService, useValue: auth },
+      { provide: Router, useValue: router },
+    ],
+  });
+
+  const fixture = TestBed.createComponent(Callback);
+  fixture.detectChanges();
+  return { fixture, auth, router, component: fixture.componentInstance };
+}
+
+describe('Callback', () => {
+  it('redirects to the stored return url after a successful sign-in', () => {
+    const { component, router } = setup({ authed: true, returnUrl: '/videos/my' });
+
+    expect(component.failed()).toBe(false);
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/videos/my', { replaceUrl: true });
+  });
+
+  it('redirects home when there is no stored return url', () => {
+    const { router } = setup({ authed: true, returnUrl: null });
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/', { replaceUrl: true });
+  });
+
+  it('shows the failure state when the session is not authenticated', () => {
+    const { component, router } = setup({ authed: false });
+
+    expect(component.failed()).toBe(true);
+    expect(router.navigateByUrl).not.toHaveBeenCalled();
+  });
+
+  it('retry() clears the failure and restarts the login flow', () => {
+    const { component, auth } = setup({ authed: false, returnUrl: '/events' });
+
+    component.retry();
+
+    expect(component.failed()).toBe(false);
+    expect(auth.login).toHaveBeenCalledWith('/events');
+  });
+});

--- a/src/my-dance.web/src/app/features/auth/logout-callback.spec.ts
+++ b/src/my-dance.web/src/app/features/auth/logout-callback.spec.ts
@@ -1,0 +1,19 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+
+import { LogoutCallback } from './logout-callback';
+
+describe('LogoutCallback', () => {
+  it('returns the user home on creation', () => {
+    const router = { navigateByUrl: vi.fn() };
+    TestBed.configureTestingModule({
+      imports: [LogoutCallback],
+      providers: [{ provide: Router, useValue: router }],
+    });
+
+    const fixture = TestBed.createComponent(LogoutCallback);
+    fixture.detectChanges();
+
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/', { replaceUrl: true });
+  });
+});

--- a/src/my-dance.web/src/app/features/auth/logout.spec.ts
+++ b/src/my-dance.web/src/app/features/auth/logout.spec.ts
@@ -1,0 +1,21 @@
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+
+import { Logout } from './logout';
+import { AuthService } from '../../core/auth/auth.service';
+
+describe('Logout', () => {
+  it('triggers logout on creation', () => {
+    const logout = vi.fn(() => of(null));
+    TestBed.configureTestingModule({
+      imports: [Logout],
+      providers: [{ provide: AuthService, useValue: { logout } }],
+    });
+
+    const fixture = TestBed.createComponent(Logout);
+    fixture.detectChanges();
+
+    expect(logout).toHaveBeenCalledTimes(1);
+    expect((fixture.nativeElement as HTMLElement).textContent).toContain('Signing you out');
+  });
+});

--- a/src/my-dance.web/src/app/features/auth/silent-renew.spec.ts
+++ b/src/my-dance.web/src/app/features/auth/silent-renew.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SilentRenew } from './silent-renew';
+
+describe('SilentRenew', () => {
+  it('creates without rendering meaningful content', () => {
+    TestBed.configureTestingModule({ imports: [SilentRenew] });
+
+    const fixture = TestBed.createComponent(SilentRenew);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance).toBeTruthy();
+    expect((fixture.nativeElement as HTMLElement).textContent?.trim()).toBe('');
+  });
+});

--- a/src/my-dance.web/src/app/features/comments/comments-section.spec.ts
+++ b/src/my-dance.web/src/app/features/comments/comments-section.spec.ts
@@ -1,0 +1,165 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CommentDraft, CommentEdit, CommentReport, CommentsSection } from './comments-section';
+import { CommentResponse } from '../../core/api/api-models';
+
+async function setup(
+  inputs: Record<string, unknown> = {},
+): Promise<ComponentFixture<CommentsSection>> {
+  await TestBed.configureTestingModule({ imports: [CommentsSection] }).compileComponents();
+  const fixture = TestBed.createComponent(CommentsSection);
+  fixture.componentRef.setInput('comments', inputs['comments'] ?? []);
+  for (const [key, value] of Object.entries(inputs)) {
+    if (key !== 'comments') {
+      fixture.componentRef.setInput(key, value);
+    }
+  }
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('CommentsSection', () => {
+  describe('authorLabel', () => {
+    it('marks anonymous authors as guests', async () => {
+      const c = (await setup()).componentInstance;
+      expect(c.authorLabel({ authorName: 'Ada', postedAsAnonymous: true })).toBe('Ada (guest)');
+    });
+
+    it('uses the plain name for signed-in authors', async () => {
+      const c = (await setup()).componentInstance;
+      expect(c.authorLabel({ authorName: 'Ada', postedAsAnonymous: false })).toBe('Ada');
+    });
+
+    it('falls back to "Someone" when the name is blank', async () => {
+      const c = (await setup()).componentInstance;
+      expect(c.authorLabel({ authorName: '   ', postedAsAnonymous: false })).toBe('Someone');
+    });
+  });
+
+  describe('new comment composer', () => {
+    it('does not emit when the content is too short', async () => {
+      const fixture = await setup({ canCompose: true });
+      const emitted: CommentDraft[] = [];
+      fixture.componentInstance.create.subscribe((d) => emitted.push(d));
+
+      fixture.componentInstance.composer.controls.content.setValue('ab');
+      fixture.componentInstance.submitNew();
+
+      expect(emitted).toEqual([]);
+    });
+
+    it('emits a trimmed draft for valid content', async () => {
+      const fixture = await setup({ canCompose: true });
+      const emitted: CommentDraft[] = [];
+      fixture.componentInstance.create.subscribe((d) => emitted.push(d));
+
+      fixture.componentInstance.composer.controls.content.setValue('  great moves  ');
+      fixture.componentInstance.submitNew();
+
+      expect(emitted).toEqual([{ content: 'great moves', authorName: undefined }]);
+    });
+
+    it('requires and includes a signature when requireSignature is set', async () => {
+      const fixture = await setup({ canCompose: true, requireSignature: true });
+      const emitted: CommentDraft[] = [];
+      fixture.componentInstance.create.subscribe((d) => emitted.push(d));
+
+      fixture.componentInstance.composer.controls.content.setValue('nice');
+      fixture.componentInstance.submitNew();
+      expect(emitted).toEqual([]); // signature missing -> invalid
+
+      fixture.componentInstance.composer.controls.authorName.setValue('Guest');
+      fixture.componentInstance.submitNew();
+      expect(emitted).toEqual([{ content: 'nice', authorName: 'Guest' }]);
+    });
+
+    it('resetComposer keeps the signature but clears the content when a signature is required', async () => {
+      const fixture = await setup({ canCompose: true, requireSignature: true });
+      fixture.componentInstance.composer.setValue({ authorName: 'Guest', content: 'hello' });
+
+      fixture.componentInstance.resetComposer();
+
+      expect(fixture.componentInstance.composer.value).toEqual({ authorName: 'Guest', content: '' });
+    });
+  });
+
+  describe('edit flow', () => {
+    const comment: CommentResponse = { id: 'c1', content: 'original' };
+
+    it('startEditing tracks the id and seeds the edit control', async () => {
+      const c = (await setup({ comments: [comment] })).componentInstance;
+      c.startEditing(comment);
+      expect(c.editingId()).toBe('c1');
+      expect(c.editControl.value).toBe('original');
+    });
+
+    it('saveEditing emits the trimmed edit and closes the editor', async () => {
+      const fixture = await setup({ comments: [comment] });
+      const emitted: CommentEdit[] = [];
+      fixture.componentInstance.saveEdit.subscribe((e) => emitted.push(e));
+
+      fixture.componentInstance.startEditing(comment);
+      fixture.componentInstance.editControl.setValue('  updated  ');
+      fixture.componentInstance.saveEditing(comment);
+
+      expect(emitted).toEqual([{ commentId: 'c1', content: 'updated' }]);
+      expect(fixture.componentInstance.editingId()).toBeNull();
+    });
+
+    it('does not emit an edit that fails validation', async () => {
+      const fixture = await setup({ comments: [comment] });
+      const emitted: CommentEdit[] = [];
+      fixture.componentInstance.saveEdit.subscribe((e) => emitted.push(e));
+
+      fixture.componentInstance.startEditing(comment);
+      fixture.componentInstance.editControl.setValue('x');
+      fixture.componentInstance.saveEditing(comment);
+
+      expect(emitted).toEqual([]);
+    });
+
+    it('cancelEditing closes the editor', async () => {
+      const c = (await setup({ comments: [comment] })).componentInstance;
+      c.startEditing(comment);
+      c.cancelEditing();
+      expect(c.editingId()).toBeNull();
+    });
+  });
+
+  describe('report flow', () => {
+    const comment: CommentResponse = { id: 'c1', content: 'x' };
+
+    it('submitReport emits the trimmed reason and closes the form', async () => {
+      const fixture = await setup({ comments: [comment] });
+      const emitted: CommentReport[] = [];
+      fixture.componentInstance.report.subscribe((r) => emitted.push(r));
+
+      fixture.componentInstance.startReport(comment);
+      fixture.componentInstance.reportControl.setValue('  spam  ');
+      fixture.componentInstance.submitReport(comment);
+
+      expect(emitted).toEqual([{ commentId: 'c1', reason: 'spam' }]);
+      expect(fixture.componentInstance.reportingId()).toBeNull();
+    });
+  });
+
+  describe('mutually exclusive edit / report panels', () => {
+    const comment: CommentResponse = { id: 'c1', content: 'x' };
+
+    it('opening the editor closes an open report form', async () => {
+      const c = (await setup({ comments: [comment] })).componentInstance;
+      c.startReport(comment);
+      c.startEditing(comment);
+      expect(c.reportingId()).toBeNull();
+      expect(c.editingId()).toBe('c1');
+    });
+
+    it('opening the report form closes an open editor', async () => {
+      const c = (await setup({ comments: [comment] })).componentInstance;
+      c.startEditing(comment);
+      c.startReport(comment);
+      expect(c.editingId()).toBeNull();
+      expect(c.reportingId()).toBe('c1');
+    });
+  });
+});

--- a/src/my-dance.web/src/app/features/events/events.spec.ts
+++ b/src/my-dance.web/src/app/features/events/events.spec.ts
@@ -95,4 +95,14 @@ describe('Events', () => {
     // load() ran once on init and once after creating.
     expect(access.getMyAccess).toHaveBeenCalledTimes(2);
   });
+
+  it('createEvent() clears the creating flag when the request fails', () => {
+    const createEvent = vi.fn(() => throwError(() => new Error('x')));
+    const { component } = createEventsFixture({ createEvent });
+
+    component.form.setValue({ name: 'Winter Ball', date: '2026-02-14' });
+    component.createEvent();
+
+    expect(component.creating()).toBe(false);
+  });
 });

--- a/src/my-dance.web/src/app/features/events/events.spec.ts
+++ b/src/my-dance.web/src/app/features/events/events.spec.ts
@@ -1,0 +1,98 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { of, throwError } from 'rxjs';
+
+import { Events } from './events';
+import { AccessService } from '../../core/api/access.service';
+import { EventsService } from '../../core/api/events.service';
+import { EventModel } from '../../core/api/api-models';
+
+const GALA: EventModel = { id: 'e1', name: 'Gala', date: new Date(2026, 0, 1) };
+
+function createEventsFixture(overrides: {
+  getMyAccess?: ReturnType<typeof vi.fn>;
+  getEventVideos?: ReturnType<typeof vi.fn>;
+  createEvent?: ReturnType<typeof vi.fn>;
+}) {
+  const access = {
+    getMyAccess: overrides.getMyAccess ?? vi.fn(() => of({ assigned: { events: [GALA] } })),
+  };
+  const events = {
+    getEventVideos: overrides.getEventVideos ?? vi.fn(() => of({ videos: [] })),
+    createEvent: overrides.createEvent ?? vi.fn(() => of({ id: 'new' })),
+  };
+
+  TestBed.configureTestingModule({
+    imports: [Events],
+    providers: [
+      provideRouter([]),
+      { provide: AccessService, useValue: access },
+      { provide: EventsService, useValue: events },
+    ],
+  });
+
+  const fixture = TestBed.createComponent(Events);
+  fixture.detectChanges();
+  return { fixture, access, events, component: fixture.componentInstance };
+}
+
+describe('Events', () => {
+  it('loads the assigned events', () => {
+    const { component } = createEventsFixture({});
+    expect(component.loading()).toBe(false);
+    expect(component.items()).toHaveLength(1);
+  });
+
+  it('enters the failed state when loading errors', () => {
+    const { component } = createEventsFixture({ getMyAccess: vi.fn(() => throwError(() => new Error('x'))) });
+    expect(component.failed()).toBe(true);
+  });
+
+  it('select() loads videos for the chosen event', () => {
+    const getEventVideos = vi.fn(() => of({ videos: [{ name: 'v1' }] }));
+    const { component, events } = createEventsFixture({ getEventVideos });
+
+    component.select(GALA);
+
+    expect(events.getEventVideos).toHaveBeenCalledWith('e1');
+    expect(component.selected()?.id).toBe('e1');
+    expect(component.videos()).toHaveLength(1);
+    expect(component.videosLoading()).toBe(false);
+  });
+
+  it('select() on an event without an id selects but loads nothing', () => {
+    const { component, events } = createEventsFixture({});
+    component.select({ name: 'No id', date: new Date(2026, 0, 1) });
+    expect(component.selected()?.name).toBe('No id');
+    expect(events.getEventVideos).not.toHaveBeenCalled();
+  });
+
+  it('select() flags a video load failure', () => {
+    const getEventVideos = vi.fn(() => throwError(() => new Error('x')));
+    const { component } = createEventsFixture({ getEventVideos });
+    component.select(GALA);
+    expect(component.videosFailed()).toBe(true);
+    expect(component.videosLoading()).toBe(false);
+  });
+
+  it('createEvent() does nothing while the form is invalid', () => {
+    const { component, events } = createEventsFixture({});
+    component.createEvent();
+    expect(events.createEvent).not.toHaveBeenCalled();
+  });
+
+  it('createEvent() submits a trimmed name and parsed date, then reloads', () => {
+    const createEvent = vi.fn(() => of({ id: 'new' }));
+    const { component, access, events } = createEventsFixture({ createEvent });
+
+    component.form.setValue({ name: '  Winter Ball  ', date: '2026-02-14' });
+    component.createEvent();
+
+    expect(events.createEvent).toHaveBeenCalledWith({
+      event: { name: 'Winter Ball', date: new Date('2026-02-14') },
+    });
+    expect(component.creating()).toBe(false);
+    // load() ran once on init and once after creating.
+    expect(access.getMyAccess).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/my-dance.web/src/app/features/home/dashboard/dashboard.spec.ts
+++ b/src/my-dance.web/src/app/features/home/dashboard/dashboard.spec.ts
@@ -1,0 +1,99 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { Observable, of, throwError } from 'rxjs';
+
+import { Dashboard } from './dashboard';
+import { VideosService } from '../../../core/api/videos.service';
+import { GroupsService } from '../../../core/api/groups.service';
+import { AccessService } from '../../../core/api/access.service';
+import { MyVideosResponse, ListGroupVideosResponse, GetUserAccessResponse } from '../../../core/api/api-models';
+
+function d(y: number, m: number, day: number): Date {
+  return new Date(y, m, day);
+}
+
+async function setup(opts: {
+  my?: Observable<MyVideosResponse>;
+  groups?: Observable<ListGroupVideosResponse>;
+  access?: Observable<GetUserAccessResponse>;
+}): Promise<ComponentFixture<Dashboard>> {
+  await TestBed.configureTestingModule({
+    imports: [Dashboard],
+    providers: [
+      provideRouter([]),
+      { provide: VideosService, useValue: { getMyVideos: () => opts.my ?? of({ videoInformation: [] }) } },
+      { provide: GroupsService, useValue: { getGroupVideos: () => opts.groups ?? of({ videos: [] }) } },
+      { provide: AccessService, useValue: { getMyAccess: () => opts.access ?? of({}) } },
+    ],
+  }).compileComponents();
+
+  const fixture = TestBed.createComponent(Dashboard);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('Dashboard', () => {
+  it('loads the three libraries and exposes their counts', async () => {
+    const c = (
+      await setup({
+        my: of({ videoInformation: [{ name: 'a' }, { name: 'b' }] }),
+        groups: of({ videos: [{ name: 'g' }] }),
+        access: of({ assigned: { events: [{ name: 'e1', date: d(2026, 0, 1) }] } }),
+      })
+    ).componentInstance;
+
+    expect(c.loading()).toBe(false);
+    expect(c.failed()).toBe(false);
+    expect(c.myCount()).toBe(2);
+    expect(c.groupCount()).toBe(1);
+    expect(c.eventCount()).toBe(1);
+  });
+
+  it('reports the latest recorded date per library, ignoring undated videos', async () => {
+    const c = (
+      await setup({
+        my: of({ videoInformation: [{ recordedDateTime: d(2026, 0, 10) }, { recordedDateTime: d(2026, 2, 1) }] }),
+        groups: of({ videos: [{ recordedDateTime: d(2026, 1, 15) }, {}] }),
+      })
+    ).componentInstance;
+
+    expect(c.myLatest()).toEqual(d(2026, 2, 1));
+    expect(c.groupLatest()).toEqual(d(2026, 1, 15));
+  });
+
+  it('has no latest date for an empty / fully-undated library', async () => {
+    const c = (await setup({ my: of({ videoInformation: [{}, {}] }) })).componentInstance;
+    expect(c.myLatest()).toBeNull();
+    expect(c.groupLatest()).toBeNull();
+  });
+
+  it('merges group and personal videos into a recent feed sorted newest-first', async () => {
+    const c = (
+      await setup({
+        my: of({ videoInformation: [{ name: 'm-old', recordedDateTime: d(2026, 0, 1) }, { name: 'no-date' }] }),
+        groups: of({
+          videos: [
+            { name: 'g-new', recordedDateTime: d(2026, 5, 1) },
+            { name: 'g-mid', recordedDateTime: d(2026, 2, 1) },
+          ],
+        }),
+      })
+    ).componentInstance;
+
+    const names = c.recent().map((v) => v.name);
+    expect(names).toEqual(['g-new', 'g-mid', 'm-old']);
+    expect(names).not.toContain('no-date');
+  });
+
+  it('caps the recent feed at five entries', async () => {
+    const videos = Array.from({ length: 8 }, (_, i) => ({ recordedDateTime: d(2026, 0, i + 1) }));
+    const c = (await setup({ my: of({ videoInformation: videos }) })).componentInstance;
+    expect(c.recent()).toHaveLength(5);
+  });
+
+  it('enters the failed state when a request errors', async () => {
+    const c = (await setup({ my: throwError(() => new Error('boom')) })).componentInstance;
+    expect(c.failed()).toBe(true);
+    expect(c.loading()).toBe(false);
+  });
+});

--- a/src/my-dance.web/src/app/features/not-found/not-found.spec.ts
+++ b/src/my-dance.web/src/app/features/not-found/not-found.spec.ts
@@ -1,0 +1,20 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+
+import { NotFound } from './not-found';
+
+describe('NotFound', () => {
+  it('renders the not-found message with a link home', async () => {
+    await TestBed.configureTestingModule({
+      imports: [NotFound],
+      providers: [provideRouter([])],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(NotFound);
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('h1')?.textContent).toContain('Page not found');
+    expect(el.querySelector('a.button')?.getAttribute('href')).toBe('/');
+  });
+});

--- a/src/my-dance.web/src/app/features/sharing/share-dialog.spec.ts
+++ b/src/my-dance.web/src/app/features/sharing/share-dialog.spec.ts
@@ -1,0 +1,175 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+
+import { ShareDialog } from './share-dialog';
+import { SharingService } from '../../core/api/sharing.service';
+import { VideosService } from '../../core/api/videos.service';
+import { SharedLinkResponse } from '../../core/api/api-models';
+
+function createFixture(overrides: {
+  getMySharedLinks?: ReturnType<typeof vi.fn>;
+  createSharedLink?: ReturnType<typeof vi.fn>;
+  revokeSharedLink?: ReturnType<typeof vi.fn>;
+  updateCommentSettings?: ReturnType<typeof vi.fn>;
+}) {
+  const sharing = {
+    getMySharedLinks: overrides.getMySharedLinks ?? vi.fn(() => of({ links: [] })),
+    createSharedLink: overrides.createSharedLink ?? vi.fn(() => of({ linkId: 'new' })),
+    revokeSharedLink: overrides.revokeSharedLink ?? vi.fn(() => of(void 0)),
+  };
+  const videos = {
+    updateCommentSettings: overrides.updateCommentSettings ?? vi.fn(() => of(void 0)),
+  };
+
+  TestBed.configureTestingModule({
+    imports: [ShareDialog],
+    providers: [
+      { provide: SharingService, useValue: sharing },
+      { provide: VideosService, useValue: videos },
+    ],
+  });
+
+  const fixture: ComponentFixture<ShareDialog> = TestBed.createComponent(ShareDialog);
+  return { fixture, sharing, videos, component: fixture.componentInstance };
+}
+
+function open(fixture: ComponentFixture<ShareDialog>, videoId = 'v1', commentVisibility = 0): void {
+  fixture.componentRef.setInput('videoId', videoId);
+  fixture.componentRef.setInput('commentVisibility', commentVisibility);
+  fixture.componentRef.setInput('open', true);
+  fixture.detectChanges();
+}
+
+describe('ShareDialog', () => {
+  it('loads only this recording’s links when opened', () => {
+    const links: SharedLinkResponse[] = [
+      { linkId: 'l1', videoId: 'v1' },
+      { linkId: 'l2', videoId: 'other' },
+    ];
+    const { fixture, component, sharing } = createFixture({
+      getMySharedLinks: vi.fn(() => of({ links })),
+    });
+
+    open(fixture);
+
+    expect(sharing.getMySharedLinks).toHaveBeenCalledTimes(1);
+    expect(component.links().map((l) => l.linkId)).toEqual(['l1']);
+  });
+
+  it('does not load links while closed', () => {
+    const { fixture, sharing } = createFixture({});
+    fixture.componentRef.setInput('videoId', 'v1');
+    fixture.detectChanges();
+    expect(sharing.getMySharedLinks).not.toHaveBeenCalled();
+  });
+
+  describe('shareUrl', () => {
+    it('uses the server-provided share url when present', () => {
+      const { component } = createFixture({});
+      expect(component.shareUrl({ shareUrl: 'https://x/y', linkId: 'l1' })).toBe('https://x/y');
+    });
+
+    it('falls back to an origin-based url built from the link id', () => {
+      const { component } = createFixture({});
+      expect(component.shareUrl({ linkId: 'l1' })).toBe(`${window.location.origin}/shared/l1`);
+    });
+  });
+
+  describe('create', () => {
+    it('creates a link from the form then refreshes the list', () => {
+      const { fixture, component, sharing } = createFixture({});
+      open(fixture);
+
+      component.create();
+
+      expect(sharing.createSharedLink).toHaveBeenCalledWith('v1', {
+        expirationDays: 7,
+        allowComments: true,
+        allowAnonymousComments: false,
+      });
+      expect(component.creating()).toBe(false);
+      expect(sharing.getMySharedLinks).toHaveBeenCalledTimes(2); // open + after create
+    });
+
+    it('does nothing when the form is invalid', () => {
+      const { fixture, component, sharing } = createFixture({});
+      open(fixture);
+      component.form.controls.expirationDays.setValue(0); // below min
+
+      component.create();
+
+      expect(sharing.createSharedLink).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('applyVisibility', () => {
+    it('persists a changed visibility and updates the saved value', () => {
+      const { fixture, component, videos } = createFixture({});
+      open(fixture, 'v1', 0);
+
+      component.selectedVisibility.set(2);
+      component.applyVisibility();
+
+      expect(videos.updateCommentSettings).toHaveBeenCalledWith('v1', { commentVisibility: 2 });
+      expect(component.savedVisibility()).toBe(2);
+      expect(component.updatingVisibility()).toBe(false);
+    });
+
+    it('does nothing when the selection equals the saved value', () => {
+      const { fixture, component, videos } = createFixture({});
+      open(fixture, 'v1', 1);
+
+      component.applyVisibility();
+
+      expect(videos.updateCommentSettings).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('revoke', () => {
+    it('revokes a link then refreshes', () => {
+      const { fixture, component, sharing } = createFixture({});
+      open(fixture);
+
+      component.revoke({ linkId: 'l1' });
+
+      expect(sharing.revokeSharedLink).toHaveBeenCalledWith('l1');
+      expect(sharing.getMySharedLinks).toHaveBeenCalledTimes(2);
+    });
+
+    it('ignores a link with no id', () => {
+      const { fixture, component, sharing } = createFixture({});
+      open(fixture);
+      component.revoke({});
+      expect(sharing.revokeSharedLink).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('copy / close', () => {
+    it('copies the share url and marks the link as copied', async () => {
+      const writeText = vi.fn(() => Promise.resolve());
+      Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+
+      const { fixture, component } = createFixture({});
+      open(fixture);
+
+      component.copy({ linkId: 'l1', shareUrl: 'https://x/y' });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(writeText).toHaveBeenCalledWith('https://x/y');
+      expect(component.copiedLinkId()).toBe('l1');
+    });
+
+    it('close() clears the copied state and emits closed', () => {
+      const { fixture, component } = createFixture({});
+      open(fixture);
+      component.copiedLinkId.set('l1');
+
+      let emitted = false;
+      component.closed.subscribe(() => (emitted = true));
+      component.close();
+
+      expect(component.copiedLinkId()).toBeNull();
+      expect(emitted).toBe(true);
+    });
+  });
+});

--- a/src/my-dance.web/src/app/features/sharing/share-dialog.spec.ts
+++ b/src/my-dance.web/src/app/features/sharing/share-dialog.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
 import { ShareDialog } from './share-dialog';
 import { SharingService } from '../../core/api/sharing.service';
@@ -170,6 +170,36 @@ describe('ShareDialog', () => {
 
       expect(component.copiedLinkId()).toBeNull();
       expect(emitted).toBe(true);
+    });
+  });
+
+  describe('resilience', () => {
+    it('empties the list when loading links fails', () => {
+      const { fixture, component } = createFixture({
+        getMySharedLinks: vi.fn(() => throwError(() => new Error('x'))),
+      });
+      open(fixture);
+      expect(component.links()).toEqual([]);
+    });
+
+    it('clears the creating flag when creation fails', () => {
+      const { fixture, component } = createFixture({
+        createSharedLink: vi.fn(() => throwError(() => new Error('x'))),
+      });
+      open(fixture);
+      component.create();
+      expect(component.creating()).toBe(false);
+    });
+
+    it('clears the updating flag when a visibility change fails', () => {
+      const { fixture, component } = createFixture({
+        updateCommentSettings: vi.fn(() => throwError(() => new Error('x'))),
+      });
+      open(fixture, 'v1', 0);
+      component.selectedVisibility.set(2);
+      component.applyVisibility();
+      expect(component.updatingVisibility()).toBe(false);
+      expect(component.savedVisibility()).toBe(0); // unchanged on failure
     });
   });
 });

--- a/src/my-dance.web/src/app/features/sharing/shared-link-viewer.spec.ts
+++ b/src/my-dance.web/src/app/features/sharing/shared-link-viewer.spec.ts
@@ -1,0 +1,156 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { WritableSignal, signal } from '@angular/core';
+import { of, throwError } from 'rxjs';
+
+import { SharedLinkViewer } from './shared-link-viewer';
+import { SharingService } from '../../core/api/sharing.service';
+import { CommentsService } from '../../core/api/comments.service';
+import { AuthService } from '../../core/auth/auth.service';
+import { AnonymousIdService } from '../../core/anonymous-id.service';
+import { SharedVideoInfoResponse } from '../../core/api/api-models';
+
+const ANON_ID = 'anon-1';
+
+function createFixture(opts: {
+  authed?: boolean;
+  info?: SharedVideoInfoResponse;
+  getSharedVideo?: ReturnType<typeof vi.fn>;
+  addCommentByLink?: ReturnType<typeof vi.fn>;
+}) {
+  const authed: WritableSignal<boolean> = signal(opts.authed ?? false);
+  const sharing = {
+    getSharedVideo:
+      opts.getSharedVideo ?? vi.fn(() => of(opts.info ?? { videoId: 'v1', name: 'Shared' })),
+    sharedStreamUrl: vi.fn(() => 'https://api/stream'),
+  };
+  const comments = {
+    getCommentsByLink: vi.fn(() => of({ comments: [] })),
+    addCommentByLink: opts.addCommentByLink ?? vi.fn(() => of({ id: 'c1' })),
+    updateComment: vi.fn(() => of(void 0)),
+    deleteComment: vi.fn(() => of(void 0)),
+    hideComment: vi.fn(() => of(void 0)),
+    unhideComment: vi.fn(() => of(void 0)),
+    reportComment: vi.fn(() => of(void 0)),
+  };
+
+  TestBed.configureTestingModule({
+    imports: [SharedLinkViewer],
+    providers: [
+      { provide: SharingService, useValue: sharing },
+      { provide: CommentsService, useValue: comments },
+      { provide: AuthService, useValue: { isAuthenticated: authed } },
+      { provide: AnonymousIdService, useValue: { getId: () => ANON_ID } },
+    ],
+  });
+
+  const fixture: ComponentFixture<SharedLinkViewer> = TestBed.createComponent(SharedLinkViewer);
+  fixture.componentRef.setInput('linkId', 'link-1');
+  fixture.detectChanges();
+  return { fixture, sharing, comments, authed, component: fixture.componentInstance };
+}
+
+describe('SharedLinkViewer', () => {
+  it('loads the shared recording, stream url, and comments', () => {
+    const { component, sharing, comments } = createFixture({ info: { videoId: 'v1', name: 'Shared' } });
+
+    expect(sharing.getSharedVideo).toHaveBeenCalledWith('link-1');
+    expect(component.info()?.name).toBe('Shared');
+    expect(component.streamUrl()).toBe('https://api/stream');
+    expect(comments.getCommentsByLink).toHaveBeenCalledWith('link-1');
+    expect(component.loading()).toBe(false);
+  });
+
+  it('enters the failed state when the link is unavailable', () => {
+    const { component } = createFixture({ getSharedVideo: vi.fn(() => throwError(() => new Error('gone'))) });
+    expect(component.failed()).toBe(true);
+    expect(component.loading()).toBe(false);
+  });
+
+  describe('canCompose', () => {
+    it('is false when the link disallows comments', () => {
+      const { component } = createFixture({ authed: true, info: { allowCommentsOnThisLink: false } });
+      expect(component.canCompose()).toBe(false);
+    });
+
+    it('is true for a signed-in user when comments are allowed', () => {
+      const { component } = createFixture({ authed: true, info: { allowCommentsOnThisLink: true } });
+      expect(component.canCompose()).toBe(true);
+    });
+
+    it('is false for an anonymous user unless anonymous comments are allowed', () => {
+      const { component } = createFixture({
+        authed: false,
+        info: { allowCommentsOnThisLink: true, allowAnonymousCommentsOnThisLink: false },
+      });
+      expect(component.canCompose()).toBe(false);
+    });
+
+    it('is true for an anonymous user when anonymous comments are allowed', () => {
+      const { component } = createFixture({
+        authed: false,
+        info: { allowCommentsOnThisLink: true, allowAnonymousCommentsOnThisLink: true },
+      });
+      expect(component.canCompose()).toBe(true);
+    });
+  });
+
+  it('requires a signature for anonymous users', () => {
+    expect(createFixture({ authed: false }).component.requireSignature()).toBe(true);
+  });
+
+  it('does not require a signature for signed-in users', () => {
+    expect(createFixture({ authed: true }).component.requireSignature()).toBe(false);
+  });
+
+  describe('onCreate', () => {
+    it('attaches the anonymous id for guests and reloads comments', () => {
+      const addCommentByLink = vi.fn(() => of({ id: 'c1' }));
+      const { component, comments } = createFixture({ authed: false, addCommentByLink });
+
+      component.onCreate({ content: 'hello', authorName: 'Guest' });
+
+      expect(addCommentByLink).toHaveBeenCalledWith('link-1', {
+        content: 'hello',
+        authorName: 'Guest',
+        anonymousId: ANON_ID,
+      });
+      expect(component.submitting()).toBe(false);
+      expect(comments.getCommentsByLink).toHaveBeenCalledTimes(2); // load + reload
+    });
+
+    it('omits the anonymous id for signed-in users', () => {
+      const addCommentByLink = vi.fn(() => of({ id: 'c1' }));
+      const { component } = createFixture({ authed: true, addCommentByLink });
+
+      component.onCreate({ content: 'hello' });
+
+      expect(addCommentByLink).toHaveBeenCalledWith('link-1', {
+        content: 'hello',
+        authorName: undefined,
+        anonymousId: undefined,
+      });
+    });
+  });
+
+  describe('moderation passthrough', () => {
+    it('edits a comment then reloads', () => {
+      const { component, comments } = createFixture({});
+      component.onSaveEdit({ commentId: 'c1', content: 'edited' });
+      expect(comments.updateComment).toHaveBeenCalledWith('c1', { content: 'edited' });
+      expect(comments.getCommentsByLink).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes, hides, unhides, and reports comments', () => {
+      const { component, comments } = createFixture({});
+      component.onRemove('c1');
+      component.onHide('c1');
+      component.onUnhide('c1');
+      component.onReport({ commentId: 'c1', reason: 'spam' });
+
+      expect(comments.deleteComment).toHaveBeenCalledWith('c1');
+      expect(comments.hideComment).toHaveBeenCalledWith('c1');
+      expect(comments.unhideComment).toHaveBeenCalledWith('c1');
+      expect(comments.reportComment).toHaveBeenCalledWith('c1', { reason: 'spam' });
+    });
+  });
+});

--- a/src/my-dance.web/src/app/features/sharing/shared-link-viewer.spec.ts
+++ b/src/my-dance.web/src/app/features/sharing/shared-link-viewer.spec.ts
@@ -130,6 +130,15 @@ describe('SharedLinkViewer', () => {
         anonymousId: undefined,
       });
     });
+
+    it('clears the submitting flag when posting fails', () => {
+      const addCommentByLink = vi.fn(() => throwError(() => new Error('x')));
+      const { component } = createFixture({ authed: true, addCommentByLink });
+
+      component.onCreate({ content: 'hello' });
+
+      expect(component.submitting()).toBe(false);
+    });
   });
 
   describe('moderation passthrough', () => {

--- a/src/my-dance.web/src/app/features/upload/upload.spec.ts
+++ b/src/my-dance.web/src/app/features/upload/upload.spec.ts
@@ -57,6 +57,12 @@ describe('Upload', () => {
     expect(component.targetsLoading()).toBe(false);
   });
 
+  it('stops the targets spinner even when access loading fails', () => {
+    const { component } = createFixture({ getMyAccess: vi.fn(() => throwError(() => new Error('x'))) });
+    expect(component.targetsLoading()).toBe(false);
+    expect(component.targets()).toEqual([]);
+  });
+
   it('tracks selected files and derived flags', () => {
     const { component } = createFixture({});
     expect(component.canSubmit()).toBe(false);

--- a/src/my-dance.web/src/app/features/upload/upload.spec.ts
+++ b/src/my-dance.web/src/app/features/upload/upload.spec.ts
@@ -1,0 +1,162 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+
+import { Upload } from './upload';
+import { UploadService } from '../../core/api/upload.service';
+import { BlobUploadService } from '../../core/api/blob-upload.service';
+import { AccessService } from '../../core/api/access.service';
+import { SharingWithType } from '../../core/api/api-models';
+
+function file(name: string): File {
+  return new File([new Uint8Array(1)], name, { type: 'video/mp4' });
+}
+
+function createFixture(overrides: {
+  getMyAccess?: ReturnType<typeof vi.fn>;
+  produceUploadUrl?: ReturnType<typeof vi.fn>;
+  upload?: ReturnType<typeof vi.fn>;
+}) {
+  const access = {
+    getMyAccess:
+      overrides.getMyAccess ??
+      vi.fn(() =>
+        of({
+          assigned: {
+            groups: [{ id: 'g1', name: 'Salsa' }],
+            events: [{ id: 'e1', name: 'Gala', date: new Date(2026, 0, 1) }],
+          },
+        }),
+      ),
+  };
+  const uploads = {
+    produceUploadUrl: overrides.produceUploadUrl ?? vi.fn(() => of({ sas: 'sas-url', videoId: 'v' })),
+  };
+  const blob = { upload: overrides.upload ?? vi.fn(() => of(100)) };
+
+  TestBed.configureTestingModule({
+    imports: [Upload],
+    providers: [
+      { provide: AccessService, useValue: access },
+      { provide: UploadService, useValue: uploads },
+      { provide: BlobUploadService, useValue: blob },
+    ],
+  });
+
+  const fixture: ComponentFixture<Upload> = TestBed.createComponent(Upload);
+  fixture.detectChanges();
+  return { fixture, access, uploads, blob, component: fixture.componentInstance };
+}
+
+describe('Upload', () => {
+  it('builds upload targets from assigned groups and events plus the private library', () => {
+    const { component } = createFixture({});
+    const targets = component.targets();
+    expect(targets.map((t) => t.key)).toEqual(['private', 'g:g1', 'e:e1']);
+    expect(targets[1]).toMatchObject({ label: 'Group: Salsa', type: SharingWithType.Group, sharedWith: 'g1' });
+    expect(targets[2]).toMatchObject({ label: 'Event: Gala', type: SharingWithType.Event, sharedWith: 'e1' });
+    expect(component.targetsLoading()).toBe(false);
+  });
+
+  it('tracks selected files and derived flags', () => {
+    const { component } = createFixture({});
+    expect(component.canSubmit()).toBe(false);
+
+    component.onFilesSelected({ target: { files: [file('a.mp4')] } } as unknown as Event);
+
+    expect(component.files()).toHaveLength(1);
+    expect(component.canSubmit()).toBe(true);
+    expect(component.singleFile()).toBe(true);
+  });
+
+  it('does nothing on submit without files', () => {
+    const { component, uploads } = createFixture({});
+    component.submit();
+    expect(uploads.produceUploadUrl).not.toHaveBeenCalled();
+  });
+
+  it('uploads a single file to the private library and finishes', () => {
+    const { component, uploads, blob } = createFixture({});
+    const f = file('lesson.mp4');
+    component.files.set([f]);
+    component.form.patchValue({ recordedDate: '2026-05-01' });
+
+    component.submit();
+
+    expect(uploads.produceUploadUrl).toHaveBeenCalledTimes(1);
+    expect(uploads.produceUploadUrl).toHaveBeenCalledWith({
+      nameOfVideo: 'lesson.mp4',
+      fileName: 'lesson.mp4',
+      recordedTimeUtc: new Date('2026-05-01'),
+      sharingWithType: SharingWithType.Private,
+      sharedWith: undefined,
+    });
+    expect(blob.upload).toHaveBeenCalledWith('sas-url', f);
+    expect(component.stage()).toBe('done');
+    expect(component.progress()).toBe(100);
+    expect(component.total()).toBe(1);
+    expect(component.currentIndex()).toBe(1);
+  });
+
+  it('applies an explicit name for a single file', () => {
+    const { component, uploads } = createFixture({});
+    component.files.set([file('lesson.mp4')]);
+    component.form.patchValue({ name: '  Cha-cha basics  ', recordedDate: '2026-05-01' });
+
+    component.submit();
+
+    expect(uploads.produceUploadUrl).toHaveBeenCalledWith(
+      expect.objectContaining({ nameOfVideo: 'Cha-cha basics', fileName: 'lesson.mp4' }),
+    );
+  });
+
+  it('names each recording after its file when uploading a batch', () => {
+    const { component, uploads } = createFixture({});
+    component.files.set([file('one.mp4'), file('two.mp4')]);
+    component.form.patchValue({ name: 'ignored for batches', recordedDate: '2026-05-01' });
+
+    component.submit();
+
+    expect(uploads.produceUploadUrl).toHaveBeenCalledTimes(2);
+    expect(uploads.produceUploadUrl).toHaveBeenNthCalledWith(1, expect.objectContaining({ nameOfVideo: 'one.mp4' }));
+    expect(uploads.produceUploadUrl).toHaveBeenNthCalledWith(2, expect.objectContaining({ nameOfVideo: 'two.mp4' }));
+    expect(component.stage()).toBe('done');
+  });
+
+  it('targets the selected group', () => {
+    const { component, uploads } = createFixture({});
+    component.files.set([file('lesson.mp4')]);
+    component.form.patchValue({ targetKey: 'g:g1', recordedDate: '2026-05-01' });
+
+    component.submit();
+
+    expect(uploads.produceUploadUrl).toHaveBeenCalledWith(
+      expect.objectContaining({ sharingWithType: SharingWithType.Group, sharedWith: 'g1' }),
+    );
+  });
+
+  it('enters the error stage when an upload fails', () => {
+    const { component } = createFixture({
+      produceUploadUrl: vi.fn(() => throwError(() => new Error('nope'))),
+    });
+    component.files.set([file('lesson.mp4')]);
+
+    component.submit();
+
+    expect(component.stage()).toBe('error');
+  });
+
+  it('reset returns to the form with cleared state', () => {
+    const { component } = createFixture({});
+    component.files.set([file('a.mp4')]);
+    component.submit();
+    expect(component.stage()).toBe('done');
+
+    component.reset();
+
+    expect(component.stage()).toBe('form');
+    expect(component.files()).toEqual([]);
+    expect(component.progress()).toBe(0);
+    expect(component.total()).toBe(0);
+    expect(component.form.getRawValue()).toEqual({ name: '', recordedDate: '', targetKey: 'private' });
+  });
+});

--- a/src/my-dance.web/src/app/features/videos/group-videos.spec.ts
+++ b/src/my-dance.web/src/app/features/videos/group-videos.spec.ts
@@ -1,0 +1,73 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { Observable, of, throwError } from 'rxjs';
+
+import { GroupVideos } from './group-videos';
+import { GroupsService } from '../../core/api/groups.service';
+import { AccessService } from '../../core/api/access.service';
+import { ListGroupVideosResponse, GetUserAccessResponse } from '../../core/api/api-models';
+
+async function setup(opts: {
+  videos?: Observable<ListGroupVideosResponse>;
+  access?: Observable<GetUserAccessResponse>;
+}): Promise<ComponentFixture<GroupVideos>> {
+  await TestBed.configureTestingModule({
+    imports: [GroupVideos],
+    providers: [
+      provideRouter([]),
+      { provide: GroupsService, useValue: { getGroupVideos: () => opts.videos ?? of({ videos: [] }) } },
+      { provide: AccessService, useValue: { getMyAccess: () => opts.access ?? of({}) } },
+    ],
+  }).compileComponents();
+
+  const fixture = TestBed.createComponent(GroupVideos);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('GroupVideos', () => {
+  it('buckets videos by group in first-seen order and attaches seasons', async () => {
+    const seasonStart = new Date(2023, 8, 1);
+    const seasonEnd = new Date(2024, 4, 1);
+    const c = (
+      await setup({
+        videos: of({
+          videos: [
+            { videoId: 'v1', groupId: 'g1', groupName: 'Salsa' },
+            { videoId: 'v2', groupId: 'g2', groupName: 'Bachata' },
+            { videoId: 'v3', groupId: 'g1', groupName: 'Salsa' },
+          ],
+        }),
+        access: of({
+          assigned: { groups: [{ id: 'g1', seasonStart, seasonEnd }] },
+          available: { groups: [{ id: 'g2', seasonStart: new Date(2022, 8, 1) }] },
+        }),
+      })
+    ).componentInstance;
+
+    const sections = c.sections();
+    expect(sections.map((s) => s.groupId)).toEqual(['g1', 'g2']);
+    expect(sections[0].videos).toHaveLength(2);
+    expect(sections[0].seasonStart).toEqual(seasonStart);
+    expect(sections[0].seasonEnd).toEqual(seasonEnd);
+    expect(sections[1].videos).toHaveLength(1);
+  });
+
+  it('falls back to "unknown" group id and "Group" name for ungrouped videos', async () => {
+    const c = (
+      await setup({ videos: of({ videos: [{ videoId: 'v1' }] }) })
+    ).componentInstance;
+
+    const sections = c.sections();
+    expect(sections).toHaveLength(1);
+    expect(sections[0].groupId).toBe('unknown');
+    expect(sections[0].groupName).toBe('Group');
+    expect(sections[0].seasonStart).toBeUndefined();
+  });
+
+  it('enters the failed state on error', async () => {
+    const c = (await setup({ videos: throwError(() => new Error('boom')) })).componentInstance;
+    expect(c.failed()).toBe(true);
+    expect(c.loading()).toBe(false);
+  });
+});

--- a/src/my-dance.web/src/app/features/videos/my-videos.spec.ts
+++ b/src/my-dance.web/src/app/features/videos/my-videos.spec.ts
@@ -1,0 +1,65 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { Observable, of, throwError } from 'rxjs';
+
+import { MyVideos } from './my-videos';
+import { VideosService } from '../../core/api/videos.service';
+import { SharingService } from '../../core/api/sharing.service';
+import { MyVideosResponse, VideoInformation } from '../../core/api/api-models';
+
+async function setup(my?: Observable<MyVideosResponse>): Promise<ComponentFixture<MyVideos>> {
+  await TestBed.configureTestingModule({
+    imports: [MyVideos],
+    providers: [
+      provideRouter([]),
+      {
+        provide: VideosService,
+        useValue: {
+          getMyVideos: () => my ?? of({ videoInformation: [] }),
+          updateCommentSettings: () => of(void 0),
+        },
+      },
+      {
+        // Injected by the embedded ShareDialog; not exercised while it is closed.
+        provide: SharingService,
+        useValue: { getMySharedLinks: () => of({ links: [] }) },
+      },
+    ],
+  }).compileComponents();
+
+  const fixture = TestBed.createComponent(MyVideos);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('MyVideos', () => {
+  it('loads the personal library', async () => {
+    const c = (await setup(of({ videoInformation: [{ name: 'a' }, { name: 'b' }] }))).componentInstance;
+    expect(c.loading()).toBe(false);
+    expect(c.failed()).toBe(false);
+    expect(c.items()).toHaveLength(2);
+  });
+
+  it('enters the failed state on error', async () => {
+    const c = (await setup(throwError(() => new Error('boom')))).componentInstance;
+    expect(c.failed()).toBe(true);
+    expect(c.loading()).toBe(false);
+  });
+
+  it('openShare targets a video and opens the dialog', async () => {
+    const c = (await setup()).componentInstance;
+    const video: VideoInformation = { videoId: 'v1', name: 'Tango' };
+
+    c.openShare(video);
+
+    expect(c.shareTarget()).toBe(video);
+    expect(c.shareOpen()).toBe(true);
+  });
+
+  it('closeShare hides the dialog', async () => {
+    const c = (await setup()).componentInstance;
+    c.openShare({ videoId: 'v1' });
+    c.closeShare();
+    expect(c.shareOpen()).toBe(false);
+  });
+});

--- a/src/my-dance.web/src/app/features/videos/video-player.spec.ts
+++ b/src/my-dance.web/src/app/features/videos/video-player.spec.ts
@@ -108,6 +108,12 @@ describe('VideoPlayer', () => {
       const { component } = createFixture({});
       expect(component.siblings()).toEqual([]);
     });
+
+    it('leaves siblings empty when the sibling request fails', () => {
+      const getVideosForGroup = vi.fn(() => throwError(() => new Error('x')));
+      const { component } = createFixture({ groupId: 'g1', getVideosForGroup });
+      expect(component.siblings()).toEqual([]);
+    });
   });
 
   describe('rename', () => {
@@ -138,6 +144,16 @@ describe('VideoPlayer', () => {
       component.nameDraft.set('   ');
       component.saveRename();
       expect(videos.renameVideo).not.toHaveBeenCalled();
+    });
+
+    it('saveRename clears the in-flight flag when the request fails', () => {
+      const renameVideo = vi.fn(() => throwError(() => new Error('x')));
+      const { component } = createFixture({ renameVideo });
+      component.startRename();
+      component.nameDraft.set('New');
+      component.saveRename();
+      expect(component.renaming()).toBe(false);
+      expect(component.info()?.name).toBe('Tango'); // unchanged on failure
     });
 
     it('cancelRename closes the editor', () => {

--- a/src/my-dance.web/src/app/features/videos/video-player.spec.ts
+++ b/src/my-dance.web/src/app/features/videos/video-player.spec.ts
@@ -1,0 +1,172 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { signal } from '@angular/core';
+import { of, throwError } from 'rxjs';
+
+import { VideoPlayer } from './video-player';
+import { VideosService } from '../../core/api/videos.service';
+import { GroupsService } from '../../core/api/groups.service';
+import { EventsService } from '../../core/api/events.service';
+import { CommentsService } from '../../core/api/comments.service';
+import { AuthService } from '../../core/auth/auth.service';
+import { VideoInformation } from '../../core/api/api-models';
+
+const CONVERTED: VideoInformation = {
+  videoId: 'vid1',
+  blobId: 'blob1',
+  name: 'Tango',
+  converted: true,
+};
+
+function createFixture(opts: {
+  video?: VideoInformation | null;
+  getVideo?: ReturnType<typeof vi.fn>;
+  renameVideo?: ReturnType<typeof vi.fn>;
+  getVideosForGroup?: ReturnType<typeof vi.fn>;
+  getEventVideos?: ReturnType<typeof vi.fn>;
+  groupId?: string;
+  eventId?: string;
+}) {
+  const video = opts.video === undefined ? CONVERTED : opts.video;
+  const videos = {
+    getVideo: opts.getVideo ?? vi.fn(() => of({ videoInformation: video })),
+    streamUrl: vi.fn(() => 'https://api/stream'),
+    renameVideo: opts.renameVideo ?? vi.fn(() => of(void 0)),
+  };
+  const groups = { getVideosForGroup: opts.getVideosForGroup ?? vi.fn(() => of({ videos: [] })) };
+  const events = { getEventVideos: opts.getEventVideos ?? vi.fn(() => of({ videos: [] })) };
+  const comments = {
+    getCommentsForVideo: vi.fn(() => of({ comments: [] })),
+    updateComment: vi.fn(() => of(void 0)),
+    deleteComment: vi.fn(() => of(void 0)),
+    hideComment: vi.fn(() => of(void 0)),
+    unhideComment: vi.fn(() => of(void 0)),
+    reportComment: vi.fn(() => of(void 0)),
+  };
+  const auth = { getAccessToken: vi.fn(() => of('token')), isAuthenticated: signal(true) };
+
+  TestBed.configureTestingModule({
+    imports: [VideoPlayer],
+    providers: [
+      provideRouter([]),
+      { provide: VideosService, useValue: videos },
+      { provide: GroupsService, useValue: groups },
+      { provide: EventsService, useValue: events },
+      { provide: CommentsService, useValue: comments },
+      { provide: AuthService, useValue: auth },
+    ],
+  });
+
+  const fixture: ComponentFixture<VideoPlayer> = TestBed.createComponent(VideoPlayer);
+  fixture.componentRef.setInput('blobId', 'blob1');
+  if (opts.groupId) fixture.componentRef.setInput('groupId', opts.groupId);
+  if (opts.eventId) fixture.componentRef.setInput('eventId', opts.eventId);
+  fixture.detectChanges();
+  return { fixture, videos, groups, events, comments, auth, component: fixture.componentInstance };
+}
+
+describe('VideoPlayer', () => {
+  it('loads a converted recording with a stream url and its comments', () => {
+    const { component, videos, comments } = createFixture({});
+
+    expect(videos.getVideo).toHaveBeenCalledWith('blob1');
+    expect(component.info()?.name).toBe('Tango');
+    expect(videos.streamUrl).toHaveBeenCalledWith('blob1', 'token');
+    expect(component.streamUrl()).toBe('https://api/stream');
+    expect(comments.getCommentsForVideo).toHaveBeenCalledWith('vid1');
+    expect(component.loading()).toBe(false);
+  });
+
+  it('does not expose a stream url for an unconverted recording', () => {
+    const { component, videos } = createFixture({ video: { videoId: 'vid1', blobId: 'blob1', converted: false } });
+    expect(component.streamUrl()).toBeNull();
+    expect(videos.streamUrl).not.toHaveBeenCalled();
+  });
+
+  it('enters the failed state when the recording cannot be loaded', () => {
+    const { component } = createFixture({ getVideo: vi.fn(() => throwError(() => new Error('boom'))) });
+    expect(component.failed()).toBe(true);
+    expect(component.loading()).toBe(false);
+  });
+
+  describe('sibling playlist', () => {
+    it('loads group siblings when a group scope is provided', () => {
+      const getVideosForGroup = vi.fn(() => of({ videos: [{ videoId: 'a' }, { videoId: 'b' }] }));
+      const { component, groups } = createFixture({ groupId: 'g1', getVideosForGroup });
+      expect(groups.getVideosForGroup).toHaveBeenCalledWith('g1');
+      expect(component.siblings()).toHaveLength(2);
+    });
+
+    it('loads event siblings when only an event scope is provided', () => {
+      const getEventVideos = vi.fn(() => of({ videos: [{ videoId: 'a' }] }));
+      const { component, events } = createFixture({ eventId: 'e1', getEventVideos });
+      expect(events.getEventVideos).toHaveBeenCalledWith('e1');
+      expect(component.siblings()).toHaveLength(1);
+    });
+
+    it('has no siblings without a scope', () => {
+      const { component } = createFixture({});
+      expect(component.siblings()).toEqual([]);
+    });
+  });
+
+  describe('rename', () => {
+    it('startRename seeds the draft from the current name', () => {
+      const { component } = createFixture({});
+      component.startRename();
+      expect(component.editingName()).toBe(true);
+      expect(component.nameDraft()).toBe('Tango');
+    });
+
+    it('saveRename persists a trimmed name and updates the header', () => {
+      const renameVideo = vi.fn(() => of(void 0));
+      const { component, videos } = createFixture({ renameVideo });
+
+      component.startRename();
+      component.nameDraft.set('  Slow Waltz  ');
+      component.saveRename();
+
+      expect(videos.renameVideo).toHaveBeenCalledWith('vid1', { newName: 'Slow Waltz' });
+      expect(component.info()?.name).toBe('Slow Waltz');
+      expect(component.editingName()).toBe(false);
+      expect(component.renaming()).toBe(false);
+    });
+
+    it('saveRename ignores a blank name', () => {
+      const { component, videos } = createFixture({});
+      component.startRename();
+      component.nameDraft.set('   ');
+      component.saveRename();
+      expect(videos.renameVideo).not.toHaveBeenCalled();
+    });
+
+    it('cancelRename closes the editor', () => {
+      const { component } = createFixture({});
+      component.startRename();
+      component.cancelRename();
+      expect(component.editingName()).toBe(false);
+    });
+  });
+
+  describe('comment moderation', () => {
+    it('edits a comment then reloads the list', () => {
+      const { component, comments } = createFixture({});
+      component.onSaveEdit({ commentId: 'c1', content: 'edited' });
+      expect(comments.updateComment).toHaveBeenCalledWith('c1', { content: 'edited' });
+      expect(comments.getCommentsForVideo).toHaveBeenCalledTimes(2); // load + reload
+    });
+
+    it('removes, hides, unhides, and reports comments', () => {
+      const { component, comments } = createFixture({});
+      component.onRemove('c1');
+      component.onHide('c1');
+      component.onUnhide('c1');
+      component.onReport({ commentId: 'c1', reason: 'spam' });
+
+      expect(comments.deleteComment).toHaveBeenCalledWith('c1');
+      expect(comments.hideComment).toHaveBeenCalledWith('c1');
+      expect(comments.unhideComment).toHaveBeenCalledWith('c1');
+      expect(comments.reportComment).toHaveBeenCalledWith('c1', { reason: 'spam' });
+    });
+  });
+});

--- a/src/my-dance.web/src/app/layout/cookie-consent/cookie-consent.spec.ts
+++ b/src/my-dance.web/src/app/layout/cookie-consent/cookie-consent.spec.ts
@@ -1,0 +1,62 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+
+import { CookieConsent } from './cookie-consent';
+import { ConfigService } from '../../core/config/config.service';
+
+const CONSENT_COOKIE = 'tbdancedanceappcookiesaccepted';
+
+function clearConsent(): void {
+  document.cookie = `${CONSENT_COOKIE}=; path=/; max-age=0`;
+}
+
+async function createComponent(): Promise<ComponentFixture<CookieConsent>> {
+  await TestBed.configureTestingModule({
+    imports: [CookieConsent],
+    providers: [
+      {
+        provide: ConfigService,
+        useValue: { config: signal({ apiBaseUrl: '', authUrl: 'https://auth.test', redirectUri: '' }) },
+      },
+    ],
+  }).compileComponents();
+
+  const fixture = TestBed.createComponent(CookieConsent);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('CookieConsent', () => {
+  beforeEach(() => clearConsent());
+  afterEach(() => clearConsent());
+
+  it('is visible when no consent cookie is present', async () => {
+    const fixture = await createComponent();
+    expect(fixture.componentInstance.visible()).toBe(true);
+    expect((fixture.nativeElement as HTMLElement).querySelector('.cookie-consent')).not.toBeNull();
+  });
+
+  it('is hidden when the consent cookie is already set', async () => {
+    document.cookie = `${CONSENT_COOKIE}=true; path=/`;
+    const fixture = await createComponent();
+    expect(fixture.componentInstance.visible()).toBe(false);
+    expect((fixture.nativeElement as HTMLElement).querySelector('.cookie-consent')).toBeNull();
+  });
+
+  it('accept() records consent and dismisses the banner', async () => {
+    const fixture = await createComponent();
+
+    (fixture.nativeElement.querySelector('.cookie-consent button') as HTMLButtonElement).click();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.visible()).toBe(false);
+    expect(document.cookie).toContain(`${CONSENT_COOKIE}=true`);
+    expect((fixture.nativeElement as HTMLElement).querySelector('.cookie-consent')).toBeNull();
+  });
+
+  it('links to the privacy policy derived from the auth url', async () => {
+    const fixture = await createComponent();
+    const link = (fixture.nativeElement as HTMLElement).querySelector('a');
+    expect(link?.getAttribute('href')).toBe('https://auth.test/policy/dancedanceapp');
+  });
+});

--- a/src/my-dance.web/src/app/layout/navbar/navbar.spec.ts
+++ b/src/my-dance.web/src/app/layout/navbar/navbar.spec.ts
@@ -1,0 +1,98 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { WritableSignal, signal } from '@angular/core';
+import { of } from 'rxjs';
+
+import { Navbar } from './navbar';
+import { AuthService } from '../../core/auth/auth.service';
+import { ConfigService } from '../../core/config/config.service';
+
+describe('Navbar', () => {
+  let authed: WritableSignal<boolean>;
+  let login: ReturnType<typeof vi.fn>;
+  let logout: ReturnType<typeof vi.fn>;
+  let fixture: ComponentFixture<Navbar>;
+  let component: Navbar;
+
+  beforeEach(async () => {
+    authed = signal(false);
+    login = vi.fn();
+    logout = vi.fn(() => of(null));
+
+    await TestBed.configureTestingModule({
+      imports: [Navbar],
+      providers: [
+        provideRouter([]),
+        { provide: AuthService, useValue: { isAuthenticated: authed, login, logout } },
+        {
+          provide: ConfigService,
+          useValue: { config: signal({ apiBaseUrl: '', authUrl: 'https://auth.test', redirectUri: '' }) },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(Navbar);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('reflects the auth state', () => {
+    expect(component.isAuthenticated()).toBe(false);
+    authed.set(true);
+    expect(component.isAuthenticated()).toBe(true);
+  });
+
+  it('toggles and closes the burger menu', () => {
+    expect(component.menuOpen()).toBe(false);
+    component.toggleMenu();
+    expect(component.menuOpen()).toBe(true);
+    component.toggleMenu();
+    expect(component.menuOpen()).toBe(false);
+
+    component.toggleMenu();
+    component.closeMenu();
+    expect(component.menuOpen()).toBe(false);
+  });
+
+  it('builds the privacy-policy url from the auth url', () => {
+    expect(component.privacyUrl()).toBe('https://auth.test/policy/dancedanceapp');
+  });
+
+  it('login() closes the menu and starts the login flow', () => {
+    component.toggleMenu();
+    component.login();
+    expect(login).toHaveBeenCalledTimes(1);
+    expect(component.menuOpen()).toBe(false);
+  });
+
+  it('logout() closes the menu and signs the user out', () => {
+    component.toggleMenu();
+    component.logout();
+    expect(logout).toHaveBeenCalledTimes(1);
+    expect(component.menuOpen()).toBe(false);
+  });
+
+  describe('template', () => {
+    it('shows a Log in button and hides nav links when signed out', () => {
+      const el = fixture.nativeElement as HTMLElement;
+      expect(el.querySelector('.navbar-end button')?.textContent).toContain('Log in');
+      expect(el.textContent).not.toContain('My recordings');
+    });
+
+    it('shows nav links and a Log out button when signed in', () => {
+      authed.set(true);
+      fixture.detectChanges();
+
+      const el = fixture.nativeElement as HTMLElement;
+      expect(el.querySelector('.navbar-end button')?.textContent).toContain('Log out');
+      expect(el.textContent).toContain('My recordings');
+    });
+
+    it('clicking the auth button signs the user out when signed in', () => {
+      authed.set(true);
+      fixture.detectChanges();
+      (fixture.nativeElement.querySelector('.navbar-end button') as HTMLButtonElement).click();
+      expect(logout).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/my-dance.web/src/app/shared/format/enums.spec.ts
+++ b/src/my-dance.web/src/app/shared/format/enums.spec.ts
@@ -1,0 +1,50 @@
+import { SharingWithType } from '../../core/api/api-models';
+import {
+  COMMENT_VISIBILITY_LABELS,
+  CommentVisibility,
+  SHARING_WITH_TYPE_LABELS,
+  commentVisibilityLabel,
+} from './enums';
+
+describe('CommentVisibility enum', () => {
+  it('pins the numeric contract shared with the backend', () => {
+    expect(CommentVisibility.LoggedInOnly).toBe(0);
+    expect(CommentVisibility.OwnerOnly).toBe(1);
+    expect(CommentVisibility.Everyone).toBe(2);
+  });
+
+  it('labels every visibility value', () => {
+    expect(COMMENT_VISIBILITY_LABELS[CommentVisibility.LoggedInOnly]).toBe(
+      'Logged-in users only',
+    );
+    expect(COMMENT_VISIBILITY_LABELS[CommentVisibility.OwnerOnly]).toBe('Only me');
+    expect(COMMENT_VISIBILITY_LABELS[CommentVisibility.Everyone]).toBe('Everyone with access');
+  });
+});
+
+describe('commentVisibilityLabel', () => {
+  it.each([
+    [0, 'Logged-in users only'],
+    [1, 'Only me'],
+    [2, 'Everyone with access'],
+  ])('maps %i to its label', (value, label) => {
+    expect(commentVisibilityLabel(value)).toBe(label);
+  });
+
+  it('returns "Unknown" for undefined', () => {
+    expect(commentVisibilityLabel(undefined)).toBe('Unknown');
+  });
+
+  it('returns "Unknown" for an out-of-range value', () => {
+    expect(commentVisibilityLabel(99)).toBe('Unknown');
+  });
+});
+
+describe('SHARING_WITH_TYPE_LABELS', () => {
+  it('labels every sharing-with type', () => {
+    expect(SHARING_WITH_TYPE_LABELS[SharingWithType.NotSpecified]).toBe('Unspecified');
+    expect(SHARING_WITH_TYPE_LABELS[SharingWithType.Group]).toBe('Group');
+    expect(SHARING_WITH_TYPE_LABELS[SharingWithType.Event]).toBe('Event');
+    expect(SHARING_WITH_TYPE_LABELS[SharingWithType.Private]).toBe('Private library');
+  });
+});

--- a/src/my-dance.web/src/app/shared/format/long-date.pipe.spec.ts
+++ b/src/my-dance.web/src/app/shared/format/long-date.pipe.spec.ts
@@ -1,0 +1,31 @@
+import { LongDatePipe } from './long-date.pipe';
+
+describe('LongDatePipe', () => {
+  let pipe: LongDatePipe;
+
+  beforeEach(() => {
+    pipe = new LongDatePipe();
+  });
+
+  it('formats a Date as "dd MMMM yyyy"', () => {
+    // Local-time constructor avoids timezone day-shift in the assertion.
+    expect(pipe.transform(new Date(2026, 5, 4))).toBe('04 June 2026');
+  });
+
+  it('zero-pads the day', () => {
+    expect(pipe.transform(new Date(2024, 0, 9))).toBe('09 January 2024');
+  });
+
+  it('formats a numeric timestamp', () => {
+    const timestamp = new Date(2023, 11, 25).getTime();
+    expect(pipe.transform(timestamp)).toBe('25 December 2023');
+  });
+
+  it('formats an ISO date-time string', () => {
+    expect(pipe.transform('2025-03-15T10:30:00')).toBe('15 March 2025');
+  });
+
+  it.each([null, undefined, ''] as const)('returns empty string for %s', (value) => {
+    expect(pipe.transform(value)).toBe('');
+  });
+});

--- a/src/my-dance.web/src/app/shared/format/season.pipe.spec.ts
+++ b/src/my-dance.web/src/app/shared/format/season.pipe.spec.ts
@@ -1,0 +1,47 @@
+import { SeasonPipe } from './season.pipe';
+
+describe('SeasonPipe', () => {
+  let pipe: SeasonPipe;
+
+  beforeEach(() => {
+    pipe = new SeasonPipe();
+  });
+
+  it('renders a two-year span when the years differ', () => {
+    expect(pipe.transform(new Date(2023, 8, 1), new Date(2024, 4, 1))).toBe('2023 – 2024');
+  });
+
+  it('renders a single year when both ends fall in the same year', () => {
+    expect(pipe.transform(new Date(2024, 0, 1), new Date(2024, 11, 31))).toBe('2024');
+  });
+
+  it('falls back to the start year when the end is missing', () => {
+    expect(pipe.transform(new Date(2022, 5, 1), null)).toBe('2022');
+  });
+
+  it('falls back to the end year when the start is missing', () => {
+    expect(pipe.transform(null, new Date(2021, 5, 1))).toBe('2021');
+  });
+
+  it('returns empty string when both ends are missing', () => {
+    expect(pipe.transform(null, undefined)).toBe('');
+  });
+
+  it('returns empty string for an empty-string start with no end', () => {
+    expect(pipe.transform('', '')).toBe('');
+  });
+
+  it('accepts ISO strings and numeric timestamps', () => {
+    expect(pipe.transform('2020-01-01T00:00:00', new Date(2021, 0, 1).getTime())).toBe(
+      '2020 – 2021',
+    );
+  });
+
+  it('treats an invalid date as a missing year', () => {
+    expect(pipe.transform('not-a-date', new Date(2030, 0, 1))).toBe('2030');
+  });
+
+  it('returns empty string when both dates are invalid', () => {
+    expect(pipe.transform('nope', 'also-nope')).toBe('');
+  });
+});

--- a/src/my-dance.web/src/app/shared/ui/video-card/video-card.spec.ts
+++ b/src/my-dance.web/src/app/shared/ui/video-card/video-card.spec.ts
@@ -1,0 +1,77 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+
+import { VideoCard } from './video-card';
+import { VideoInformation } from '../../../core/api/api-models';
+
+const CONVERTED: VideoInformation = {
+  videoId: 'v1',
+  blobId: 'blob1',
+  name: 'Waltz basics',
+  recordedDateTime: new Date(2026, 5, 4),
+  duration: '3:21',
+  converted: true,
+};
+
+async function setup(
+  video: VideoInformation,
+  inputs: Partial<{ shareable: boolean; selected: boolean; queryParams: Record<string, string> }> = {},
+): Promise<ComponentFixture<VideoCard>> {
+  await TestBed.configureTestingModule({
+    imports: [VideoCard],
+    providers: [provideRouter([])],
+  }).compileComponents();
+
+  const fixture = TestBed.createComponent(VideoCard);
+  fixture.componentRef.setInput('video', video);
+  for (const [key, value] of Object.entries(inputs)) {
+    fixture.componentRef.setInput(key, value);
+  }
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('VideoCard', () => {
+  it('renders the name, formatted recorded date, and duration', async () => {
+    const el = (await setup(CONVERTED)).nativeElement as HTMLElement;
+    expect(el.querySelector('h3')?.textContent).toContain('Waltz basics');
+    const meta = el.querySelector('p')?.textContent ?? '';
+    expect(meta).toContain('04 June 2026');
+    expect(meta).toContain('3:21');
+  });
+
+  it('links Watch to the player using the blob id and query params', async () => {
+    const el = (await setup(CONVERTED, { queryParams: { groupId: 'g1' } })).nativeElement as HTMLElement;
+    const watch = el.querySelector('a.button.is-primary');
+    expect(watch?.textContent).toContain('Watch');
+    expect(watch?.getAttribute('href')).toBe('/videos/blob1?groupId=g1');
+  });
+
+  it('shows a processing tag instead of Watch until the video is converted', async () => {
+    const el = (await setup({ ...CONVERTED, converted: false })).nativeElement as HTMLElement;
+    expect(el.querySelector('a.button.is-primary')).toBeNull();
+    expect(el.textContent).toContain('Processing');
+  });
+
+  it('hides the Share action by default', async () => {
+    const el = (await setup(CONVERTED)).nativeElement as HTMLElement;
+    expect(el.querySelector('button')).toBeNull();
+  });
+
+  it('emits the video when the Share action is used', async () => {
+    const fixture = await setup(CONVERTED, { shareable: true });
+    const emitted: VideoInformation[] = [];
+    fixture.componentInstance.share.subscribe((v) => emitted.push(v));
+
+    const button = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
+    expect(button.textContent).toContain('Share');
+    button.click();
+
+    expect(emitted).toEqual([CONVERTED]);
+  });
+
+  it('highlights the card when selected', async () => {
+    const el = (await setup(CONVERTED, { selected: true })).nativeElement as HTMLElement;
+    expect(el.querySelector('.card')?.classList).toContain('has-background-link-light');
+  });
+});

--- a/src/my-dance.web/src/app/shared/ui/video-list/video-list.spec.ts
+++ b/src/my-dance.web/src/app/shared/ui/video-list/video-list.spec.ts
@@ -1,0 +1,71 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+
+import { VideoList } from './video-list';
+import { VideoInformation } from '../../../core/api/api-models';
+
+const VIDEOS: VideoInformation[] = [
+  { videoId: 'v1', blobId: 'b1', name: 'One', converted: true },
+  { videoId: 'v2', blobId: 'b2', name: 'Two', converted: true },
+];
+
+async function setup(
+  inputs: Record<string, unknown>,
+): Promise<ComponentFixture<VideoList>> {
+  await TestBed.configureTestingModule({
+    imports: [VideoList],
+    providers: [provideRouter([])],
+  }).compileComponents();
+
+  const fixture = TestBed.createComponent(VideoList);
+  for (const [key, value] of Object.entries(inputs)) {
+    fixture.componentRef.setInput(key, value);
+  }
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('VideoList', () => {
+  it('shows the default empty message when there are no videos', async () => {
+    const el = (await setup({ videos: [] })).nativeElement as HTMLElement;
+    expect(el.querySelector('app-video-card')).toBeNull();
+    expect(el.textContent).toContain('No recordings yet.');
+  });
+
+  it('shows a custom empty message', async () => {
+    const el = (await setup({ videos: [], emptyMessage: 'Nothing here' })).nativeElement as HTMLElement;
+    expect(el.textContent).toContain('Nothing here');
+  });
+
+  it('renders one card per video', async () => {
+    const el = (await setup({ videos: VIDEOS })).nativeElement as HTMLElement;
+    expect(el.querySelectorAll('app-video-card')).toHaveLength(2);
+  });
+
+  it('passes the shareable flag down so cards show the Share action', async () => {
+    const el = (await setup({ videos: VIDEOS, shareable: true })).nativeElement as HTMLElement;
+    expect(el.querySelectorAll('button')).toHaveLength(2);
+  });
+
+  describe('queryParams scope', () => {
+    it('uses groupId when a group scope is set', async () => {
+      const fixture = await setup({ videos: VIDEOS, scopeGroupId: 'g1' });
+      expect(fixture.componentInstance.queryParams()).toEqual({ groupId: 'g1' });
+    });
+
+    it('uses eventId when only an event scope is set', async () => {
+      const fixture = await setup({ videos: VIDEOS, scopeEventId: 'e1' });
+      expect(fixture.componentInstance.queryParams()).toEqual({ eventId: 'e1' });
+    });
+
+    it('prefers the group scope when both are set', async () => {
+      const fixture = await setup({ videos: VIDEOS, scopeGroupId: 'g1', scopeEventId: 'e1' });
+      expect(fixture.componentInstance.queryParams()).toEqual({ groupId: 'g1' });
+    });
+
+    it('is empty when no scope is set', async () => {
+      const fixture = await setup({ videos: VIDEOS });
+      expect(fixture.componentInstance.queryParams()).toEqual({});
+    });
+  });
+});


### PR DESCRIPTION
## What & why

The `my-dance.web` Angular app had a **single** test (`app.spec.ts`), and the
`gated-frontend` CI job only **built** the app — it never ran tests. This PR adds a
broad unit-test suite and wires it into the PR gate.

- **1 → 241 tests** across 37 spec files
- **~90% line / 87% branch** coverage (TS logic mostly 94–100%)
- Tests run in jsdom via Vitest (`@angular/build:unit-test`), mocking HTTP with
  `HttpTestingController` — **no live API dependency**, so they run anywhere CI does.

## Coverage added

| Layer | What's tested |
|-------|---------------|
| Format/enums | `LongDatePipe`, `SeasonPipe`, comment-visibility & sharing-type labels |
| Core | `ConfigService` (load/normalize/fallback/single-fetch), `AnonymousIdService`, `AuthService` (OIDC signal state + returnUrl), `authGuard`/`adminGuard` |
| API | `ApiClient` (url join, trailing-slash, verbs, options) + Videos/Comments/Sharing/Events/Groups/Access/Upload + `BlobUploadService` (single vs block upload, progress→%, block-id stability, block-list commit) |
| Shared/layout | `VideoCard`, `VideoList`, `Navbar`, `CookieConsent`, `NotFound`, auth pages (Callback/Logout/LogoutCallback/SilentRenew) |
| Features | Dashboard, MyVideos, GroupVideos, VideoPlayer, Upload, ShareDialog, SharedLinkViewer, CommentsSection, Events, AccessRequests, RequestAccess — incl. error/resilience branches |

## CI

`.github/workflows/pr-gated.yaml` → `gated-frontend`:
- adds a `npm run test:ci` step (headless, single-run Vitest) **before** the build;
  verified that a failing test exits non-zero, so the gate actually blocks
- adds npm caching for faster installs

## Tooling

- `package.json`: `test:ci` and `test:coverage` scripts
- adds `@vitest/coverage-v8` dev dependency (for `npm run test:coverage`)

## Notes

- No production/app code changed — specs, CI, and test tooling only.
- Pre-existing `NG8102` template warning in `request-access.html:47` is unrelated and left as-is.
