### PR TITLE
Angular SPA: upload pipeline, events, UI improvements, and test coverage

### DIFF
--- a/.claude/skills/local-stack/SKILL.md
+++ b/.claude/skills/local-stack/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: local-stack
+description: >-
+  Run, debug, and inspect the TB.DanceDance app locally via Docker Compose
+  (local_environment.dockercompose.yaml). Use for building/starting/stopping/restarting
+  the whole stack or a single container, tailing logs, checking status, resetting state
+  (DB + blob volumes), waiting for seed data, and fetching a user/converter access token
+  by HTTP for hitting the API. Triggers: "start the app locally", "restart the api
+  container", "reset the local db", "get me a token", "why is the converter failing",
+  "tail the auth server logs".
+---
+
+# Local stack (Docker) — run & debug TB.DanceDance
+
+The local environment is defined entirely in `local_environment.dockercompose.yaml` at the
+repo root. **Every compose command must pass `-f local_environment.dockercompose.yaml`** —
+there is no default `docker-compose.yml`. Run commands from the repo root
+(`C:\workspace\TB.DanceDance`).
+
+> Shorthand used below: `DC = docker compose -f local_environment.dockercompose.yaml`
+
+## Services, containers, and reachable URLs
+
+| Service        | Container name      | Reachable at (host)                        | Role |
+|----------------|---------------------|--------------------------------------------|------|
+| `api`          | `tbdancedanceapi`   | `https://localhost:7068` (+ `:8080` http)  | ASP.NET Core REST API |
+| `authserver`   | `tbauthserver`      | `https://localhost:7259` (+ `:5296` http)  | OpenIddict OIDC / token endpoint |
+| `frontendspa`  | `tbdancefrontend`   | `http://localhost:3000`                     | Angular SPA |
+| `converter`    | `tbdanceconverter`  | —                                           | Polls API, runs FFmpeg |
+| `postgresDb`   | (compose-generated) | `localhost:5432`                            | PostgreSQL (db `dancedance`, `tbauthwebdb`) |
+| `azuriteStorage`| (compose-generated)| `localhost:10000-10002`                     | Azure Blob emulator |
+| `initializator`| `tbdanceInitializer`| — (one-shot)                                | Seeds DB + blobs, then exits |
+
+The auth server is HTTPS-only for browser flows; HTTP `:5296` 307-redirects to HTTPS.
+
+## Prerequisites (one-time)
+
+The API and auth server mount a dev cert and read an env file. If `up` fails on a missing
+cert/file, generate them first:
+
+```powershell
+# Dev TLS cert mounted by api + authserver (volume: $USERPROFILE\.aspnet\https\aspnetapp.pfx)
+dotnet dev-certs https --clean
+dotnet dev-certs https -ep $env:USERPROFILE\.aspnet\https\aspnetapp.pfx -p 2918379123298173918273861
+
+tools\generateAuthSigningCert.ps1   # writes .env.authserver-certs (used by authserver)
+```
+
+## Lifecycle commands
+
+### Bring the whole stack up
+```powershell
+docker compose -f local_environment.dockercompose.yaml up -d --build   # build images + start
+docker compose -f local_environment.dockercompose.yaml up -d           # start without rebuild
+```
+Then **wait for seed data** before using the app — the initializer is one-shot:
+```powershell
+docker logs -f tbdanceInitializer    # wait for the line: Data initialized
+```
+
+### Status / logs
+```powershell
+docker compose -f local_environment.dockercompose.yaml ps              # what's running
+docker compose -f local_environment.dockercompose.yaml logs -f api     # tail one service
+docker compose -f local_environment.dockercompose.yaml logs --tail=200 authserver converter
+```
+
+### Single container — start / stop / restart / rebuild
+```powershell
+docker compose -f local_environment.dockercompose.yaml up -d api               # start/ensure one
+docker compose -f local_environment.dockercompose.yaml restart api             # restart one
+docker compose -f local_environment.dockercompose.yaml stop converter          # stop one
+docker compose -f local_environment.dockercompose.yaml up -d --build api       # rebuild + restart one
+```
+After changing backend C# code, rebuild the affected image (`api`, `authserver`, or
+`converter`) with `up -d --build <service>` — a plain `restart` reuses the old image.
+
+### Stop / tear down
+```powershell
+docker compose -f local_environment.dockercompose.yaml stop            # stop, keep containers
+docker compose -f local_environment.dockercompose.yaml down            # remove containers, KEEP volumes
+docker compose -f local_environment.dockercompose.yaml down -v         # FULL RESET: also wipe DB + blob volumes
+```
+`down -v` deletes `postgresDance` and `azuriteStorageDance` — all seeded users, videos,
+and blobs are lost and the initializer must re-run on next `up`. Use it when state is
+corrupt; confirm with the user first since it is destructive.
+
+### Frontend hot-reload (skip the SPA container)
+```powershell
+docker compose -f local_environment.dockercompose.yaml up -d --scale frontendspa=0
+cd src/my-dance.web; npm start        # serves on http://localhost:3000
+```
+
+## Getting an access token (HTTP)
+
+Local dev enables the OAuth2 **password grant** (`AuthServer:AllowWeakPasswords=true`), so a
+single REST call returns a JWT. Two seeded users, both password `1234`:
+`testemail@email.com` (user 1) and `testemail2@email.com` (user 2).
+
+Use the bundled helper (works in PowerShell 5.1 and 7; uses `curl.exe -k` for the dev cert):
+
+```powershell
+# token metadata -> stderr, raw JWT -> stdout
+.\.claude\skills\local-stack\scripts\get-token.ps1                 # user 1, read scope
+.\.claude\skills\local-stack\scripts\get-token.ps1 -User 2         # second user
+$t = .\.claude\skills\local-stack\scripts\get-token.ps1 -Raw       # capture only the JWT
+.\.claude\skills\local-stack\scripts\get-token.ps1 -Convert        # converter (client_credentials)
+```
+
+Then call the API:
+```powershell
+curl.exe -k -H "Authorization: Bearer $t" https://localhost:7068/<endpoint>
+```
+Video streaming endpoints take the JWT as a query param instead (`?token=...`) because
+`<video>` elements can't send an Authorization header.
+
+Raw request (what the helper sends), also in `src/backend/Application/httpRequests/token.http`:
+```
+POST https://localhost:7259/connect/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=password&client_id=tbdancedancehttpclient&username=testemail@email.com&password=1234&scope=openid profile tbdancedanceapi.read
+```
+
+## Inspecting the databases
+
+Two databases on `localhost:5432` (user `postgres`, password `rgFraWIuyxONqWCQ71wh`):
+`dancedance` (app — schemas `access`, `video`, `comments`, default/users) and `tbauthwebdb`
+(auth server). The `postgres-dancedance` and `postgres-auth` MCP `query` tools are wired to
+these; prefer them for read-only SQL, or use `psql` via the `postgres-cli-tools` skill.
+
+## Debugging playbook
+
+- **App won't authenticate / 401s** — confirm `tbauthserver` is up and discovery works:
+  `curl.exe -k https://localhost:7259/.well-known/openid-configuration`. Issuer must be
+  `https://localhost:7259/`.
+- **API up but no data** — the initializer hasn't finished or failed:
+  `docker logs tbdanceInitializer` (look for `Data initialized`).
+- **Converter not processing** — `docker compose -f local_environment.dockercompose.yaml logs -f converter`;
+  it polls every `DelayInMinutes=1` and authenticates via client credentials (`-Convert` token).
+- **Code change not taking effect** — rebuild the image (`up -d --build <service>`), don't just `restart`.
+- **State looks corrupt** — `down -v` then `up -d --build` for a clean reseed (destructive; confirm first).

--- a/.claude/skills/local-stack/scripts/get-token.ps1
+++ b/.claude/skills/local-stack/scripts/get-token.ps1
@@ -1,0 +1,89 @@
+<#
+.SYNOPSIS
+    Fetch a user access token from the local TB.DanceDance auth server (dev only).
+
+.DESCRIPTION
+    Uses the OAuth2 password grant, which is enabled locally because the compose file
+    sets AuthServer:AllowWeakPasswords=true. Two users are seeded, both password "1234":
+      1 -> testemail@email.com
+      2 -> testemail2@email.com
+
+    Uses curl.exe (-k) so it works under both Windows PowerShell 5.1 and PowerShell 7
+    without -SkipCertificateCheck. Prints token metadata to stderr and the raw token to
+    stdout, so `$t = ./get-token.ps1 -Raw` captures just the JWT.
+
+.EXAMPLE
+    ./get-token.ps1                 # token for user 1, default read scope
+    ./get-token.ps1 -User 2         # token for the second seeded user
+    ./get-token.ps1 -Raw            # print only the JWT (for piping/capture)
+    ./get-token.ps1 -Convert        # converter daemon token (client_credentials)
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet('1', '2')]
+    [string]$User = '1',
+    [string]$Scope,
+    [string]$AuthUrl = 'https://localhost:7259',
+    [switch]$Convert,
+    [switch]$Raw
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($Convert) {
+    # Converter daemon: OAuth2 client credentials (no user).
+    $effectiveScope = if ($Scope) { $Scope } else { 'tbdancedanceapi.convert' }
+    $fields = @{
+        grant_type    = 'client_credentials'
+        client_id     = 'tbdancedanceconverter'
+        client_secret = 'Other'
+        scope         = $effectiveScope
+    }
+    $who = 'tbdancedanceconverter (client_credentials)'
+}
+else {
+    $users = @{ '1' = 'testemail@email.com'; '2' = 'testemail2@email.com' }
+    $username = $users[$User]
+    $effectiveScope = if ($Scope) { $Scope } else { 'openid profile tbdancedanceapi.read' }
+    $fields = @{
+        grant_type = 'password'
+        client_id  = 'tbdancedancehttpclient'
+        username   = $username
+        password   = '1234'
+        scope      = $effectiveScope
+    }
+    $who = $username
+}
+
+# URL-encode each field value into an x-www-form-urlencoded body.
+$body = ($fields.GetEnumerator() | ForEach-Object {
+        "$($_.Key)=$([uri]::EscapeDataString([string]$_.Value))"
+    }) -join '&'
+
+$response = curl.exe -s -k -X POST "$AuthUrl/connect/token" `
+    -H 'Content-Type: application/x-www-form-urlencoded' `
+    -H 'Accept: application/json' `
+    --data $body
+
+if (-not $response) {
+    Write-Error "No response from $AuthUrl/connect/token. Is the auth server (tbauthserver) running?"
+    exit 1
+}
+
+try { $json = $response | ConvertFrom-Json } catch {
+    Write-Error "Unexpected (non-JSON) response: $response"
+    exit 1
+}
+
+if (-not $json.access_token) {
+    Write-Error "Token request failed: $response"
+    exit 1
+}
+
+# Metadata to stderr so stdout stays clean for capture/piping.
+[Console]::Error.WriteLine("User:       $who")
+[Console]::Error.WriteLine("Scope:      $effectiveScope")
+[Console]::Error.WriteLine("Expires in: $($json.expires_in)s")
+[Console]::Error.WriteLine('')
+
+$json.access_token

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ The backend follows a strict layered architecture under `src/backend/`:
 - The API validates tokens via JWT Bearer middleware; issuer discovery uses the HTTP endpoint of the auth server (`:8080`).
 - Video streaming endpoints accept the JWT in a query parameter (`token=...`) because `<video>` elements cannot send Authorization headers.
 - The converter daemon uses OAuth2 client credentials flow (not user login).
+- **Local dev only** (`AuthServer:AllowWeakPasswords=true`): the auth server also enables the OAuth2 password grant at `/connect/token` for the public `tbdancedancehttpclient` client, so any seeded user (`testemail@email.com`, `testemail2@email.com`, password `1234`) can fetch a token with a single REST call. Never enabled outside development. See `README.md` and `src/backend/Application/httpRequests/token.http`.
 
 ### Database
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,25 @@ When you see "Data initialized", the application is ready to use.
 Once the environment is up, you can access the frontend at `http://localhost:3000`.
 
 Test credentials:
-- **Login:** testemail@email.com
-- **Password:** 1234
+- **Login:** testemail@email.com — **Password:** 1234 (full access: all groups and events)
+- **Login:** testemail2@email.com — **Password:** 1234 (limited access: only the "Środy 18:00" group)
+
+## Get a token via REST (dev only)
+
+In local development the auth server enables the OAuth2 password grant, so you can obtain a
+user token with a single REST call (no browser login). This is gated by
+`AuthServer:AllowWeakPasswords=true` and is **never** enabled outside development.
+
+```bash
+curl -k -X POST https://localhost:7259/connect/token \
+  -d grant_type=password -d client_id=tbdancedancehttpclient \
+  -d username=testemail@email.com -d password=1234 \
+  -d "scope=openid profile tbdancedanceapi.read"
+```
+
+The response JSON contains `access_token`. Send it to the API as a bearer token:
+`Authorization: Bearer <access_token>`. A ready-to-run sample lives in
+`src/backend/Application/httpRequests/token.http`.
 
 ## Mobile App
 

--- a/src/authserver/Configuration.cs
+++ b/src/authserver/Configuration.cs
@@ -29,6 +29,11 @@ public static class Configuration
                     .AllowRefreshTokenFlow()
                     .AllowClientCredentialsFlow();
 
+                // Dev-only: enable the OAuth2 password grant so any seeded user can mint a
+                // token via a single REST call. Gated by the same flag that enables /dev/*.
+                if (authOptions.AllowWeakPasswords)
+                    options.AllowPasswordFlow();
+
                 var signingCert = LoadCertIfPresent(
                     authOptions.ServerSigningCertificateBase64,
                     authOptions.ServerSigningCertificatePassword);

--- a/src/authserver/Endpoints/Handlers/ConnectAuthorizeHandler.cs
+++ b/src/authserver/Endpoints/Handlers/ConnectAuthorizeHandler.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.IdentityModel.Tokens;
 using OpenIddict.Abstractions;
 using OpenIddict.Server.AspNetCore;
 using static OpenIddict.Abstractions.OpenIddictConstants;
@@ -52,50 +51,10 @@ public static class ConnectAuthorizeHandler
             return Results.BadRequest("Authenticated user was not found in identity store.");
         }
 
-        var userClaims = await userManager.GetClaimsAsync(user);
+        var principalToIssue = await UserTokenIdentityFactory.BuildAsync(
+            user, userManager, await ResolveScopesAsync(context), scopeManager);
 
-        var identity = new ClaimsIdentity(
-            authenticationType: TokenValidationParameters.DefaultAuthenticationType,
-            nameType: Claims.Name,
-            roleType: Claims.Role);
-
-        identity.AddClaim(
-            new Claim(Claims.Subject, user.Id).SetDestinations(Destinations.AccessToken, Destinations.IdentityToken));
-
-        var username = user.UserName ?? user.Email ?? user.Id;
-        identity.AddClaim(
-            new Claim(Claims.PreferredUsername, username).SetDestinations(Destinations.AccessToken,
-                Destinations.IdentityToken));
-
-        var name = userClaims.FirstOrDefault(claim => claim.Type == ClaimTypes.Name)?.Value ?? username;
-        identity.AddClaim(
-            new Claim(Claims.Name, name).SetDestinations(Destinations.AccessToken, Destinations.IdentityToken));
-
-        var email = userClaims.FirstOrDefault(claim => claim.Type == ClaimTypes.Email)?.Value ?? user.Email;
-        if (!string.IsNullOrWhiteSpace(email))
-        {
-            identity.AddClaim(
-                new Claim(Claims.Email, email).SetDestinations(Destinations.AccessToken, Destinations.IdentityToken));
-        }
-
-        var givenName = userClaims.FirstOrDefault(claim => claim.Type == ClaimTypes.GivenName)?.Value;
-        if (!string.IsNullOrWhiteSpace(givenName))
-        {
-            identity.AddClaim(new Claim(Claims.GivenName, givenName).SetDestinations(Destinations.AccessToken,
-                Destinations.IdentityToken));
-        }
-
-        var familyName = userClaims.FirstOrDefault(claim => claim.Type == ClaimTypes.Surname)?.Value;
-        if (!string.IsNullOrWhiteSpace(familyName))
-        {
-            identity.AddClaim(new Claim(Claims.FamilyName, familyName).SetDestinations(Destinations.AccessToken,
-                Destinations.IdentityToken));
-        }
-
-        identity.SetScopes(await ResolveScopesAsync(context));
-        identity.SetResources(await scopeManager.ListResourcesAsync(identity.GetScopes()).ToListAsync());
-
-        return Results.SignIn(new ClaimsPrincipal(identity), properties: null,
+        return Results.SignIn(principalToIssue, properties: null,
             OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
     }
 

--- a/src/authserver/Endpoints/Handlers/TokenHandler.cs
+++ b/src/authserver/Endpoints/Handlers/TokenHandler.cs
@@ -1,15 +1,21 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.IdentityModel.Tokens;
 using OpenIddict.Abstractions;
 using OpenIddict.Server.AspNetCore;
+using TB.Auth.Web.Identity;
 using static OpenIddict.Abstractions.OpenIddictConstants;
 
 namespace TB.Auth.Web.Endpoints.Handlers;
 
 public static class TokenHandler
 {
-    public static async Task<IResult> HandleAsync(HttpContext context, IOpenIddictScopeManager scopeManager)
+    public static async Task<IResult> HandleAsync(
+        HttpContext context,
+        IOpenIddictScopeManager scopeManager,
+        UserManager<User> userManager,
+        AuthServerOptions authOptions)
     {
         var form = context.Request.HasFormContentType
             ? await context.Request.ReadFormAsync()
@@ -58,6 +64,40 @@ public static class TokenHandler
             identity.SetResources(await scopeManager.ListResourcesAsync(identity.GetScopes()).ToListAsync());
 
             return Results.SignIn(new ClaimsPrincipal(identity), properties: null,
+                OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+        }
+
+        // Dev-only: Resource Owner Password Credentials grant. Lets any seeded user obtain a
+        // token via a single REST call. The flow itself is only registered when
+        // AllowWeakPasswords is true (see Configuration.AddServerWithConfiguration); the guard
+        // below is defense in depth.
+        if (string.Equals(grantType, GrantTypes.Password, StringComparison.Ordinal) &&
+            authOptions.AllowWeakPasswords)
+        {
+            var login = form?["username"].ToString().Trim();
+            var password = form?["password"].ToString();
+
+            if (string.IsNullOrWhiteSpace(login) || string.IsNullOrWhiteSpace(password))
+            {
+                return Results.BadRequest("Username and password are required.");
+            }
+
+            var user = await userManager.FindByNameAsync(login);
+            if (user is null && login.Contains('@'))
+            {
+                user = await userManager.FindByEmailAsync(login);
+            }
+
+            if (user is null || !await userManager.CheckPasswordAsync(user, password))
+            {
+                return Results.Forbid(
+                    authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
+            }
+
+            var principal = await UserTokenIdentityFactory.BuildAsync(
+                user, userManager, ScopeParser.ParseScopes(form?["scope"].ToString()), scopeManager);
+
+            return Results.SignIn(principal, properties: null,
                 OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
         }
 

--- a/src/authserver/Endpoints/Handlers/UserTokenIdentityFactory.cs
+++ b/src/authserver/Endpoints/Handlers/UserTokenIdentityFactory.cs
@@ -1,0 +1,69 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.IdentityModel.Tokens;
+using OpenIddict.Abstractions;
+using TB.Auth.Web.Identity;
+using static OpenIddict.Abstractions.OpenIddictConstants;
+
+namespace TB.Auth.Web.Endpoints.Handlers;
+
+/// <summary>
+/// Builds the OpenIddict <see cref="ClaimsPrincipal"/> issued for a user, with claims,
+/// destinations, scopes and resources. Shared by the authorization-code flow
+/// (<see cref="ConnectAuthorizeHandler"/>) and the dev-only password grant
+/// (<see cref="TokenHandler"/>) so the token shape stays identical across flows.
+/// </summary>
+public static class UserTokenIdentityFactory
+{
+    public static async Task<ClaimsPrincipal> BuildAsync(
+        User user,
+        UserManager<User> userManager,
+        IEnumerable<string> scopes,
+        IOpenIddictScopeManager scopeManager)
+    {
+        var userClaims = await userManager.GetClaimsAsync(user);
+
+        var identity = new ClaimsIdentity(
+            authenticationType: TokenValidationParameters.DefaultAuthenticationType,
+            nameType: Claims.Name,
+            roleType: Claims.Role);
+
+        identity.AddClaim(
+            new Claim(Claims.Subject, user.Id).SetDestinations(Destinations.AccessToken, Destinations.IdentityToken));
+
+        var username = user.UserName ?? user.Email ?? user.Id;
+        identity.AddClaim(
+            new Claim(Claims.PreferredUsername, username).SetDestinations(Destinations.AccessToken,
+                Destinations.IdentityToken));
+
+        var name = userClaims.FirstOrDefault(claim => claim.Type == ClaimTypes.Name)?.Value ?? username;
+        identity.AddClaim(
+            new Claim(Claims.Name, name).SetDestinations(Destinations.AccessToken, Destinations.IdentityToken));
+
+        var email = userClaims.FirstOrDefault(claim => claim.Type == ClaimTypes.Email)?.Value ?? user.Email;
+        if (!string.IsNullOrWhiteSpace(email))
+        {
+            identity.AddClaim(
+                new Claim(Claims.Email, email).SetDestinations(Destinations.AccessToken, Destinations.IdentityToken));
+        }
+
+        var givenName = userClaims.FirstOrDefault(claim => claim.Type == ClaimTypes.GivenName)?.Value;
+        if (!string.IsNullOrWhiteSpace(givenName))
+        {
+            identity.AddClaim(new Claim(Claims.GivenName, givenName).SetDestinations(Destinations.AccessToken,
+                Destinations.IdentityToken));
+        }
+
+        var familyName = userClaims.FirstOrDefault(claim => claim.Type == ClaimTypes.Surname)?.Value;
+        if (!string.IsNullOrWhiteSpace(familyName))
+        {
+            identity.AddClaim(new Claim(Claims.FamilyName, familyName).SetDestinations(Destinations.AccessToken,
+                Destinations.IdentityToken));
+        }
+
+        identity.SetScopes(scopes);
+        identity.SetResources(await scopeManager.ListResourcesAsync(identity.GetScopes()).ToListAsync());
+
+        return new ClaimsPrincipal(identity);
+    }
+}

--- a/src/backend/Application/httpRequests/token.http
+++ b/src/backend/Application/httpRequests/token.http
@@ -1,9 +1,10 @@
-﻿###
-POST https://localhost:7068/connect/token
+### Get a user token via the OAuth2 password grant (LOCAL DEV ONLY).
+### Requires the auth server running with AuthServer:AllowWeakPasswords=true.
+### Seeded users (password 1234): testemail@email.com, testemail2@email.com
+POST https://localhost:7259/connect/token
 Content-Type: application/x-www-form-urlencoded
 Accept: application/json
-Authorization: Basic dGJkYW5jZWRhbmNlaHR0cGNsaWVudDpzZWNyZXRmb3Jsb2NhbGh0dHBjbGllbnQ=
 
-grant_type=password&username=testemail@email.com&password=1234&scope=openid profile tbdancedanceapi.read
+grant_type=password&client_id=tbdancedancehttpclient&username=testemail@email.com&password=1234&scope=openid profile tbdancedanceapi.read
 
 > {% client.global.set("token", response.body.access_token); %}

--- a/src/my-dance.web/src/app/features/events/events.html
+++ b/src/my-dance.web/src/app/features/events/events.html
@@ -25,7 +25,12 @@
         <h2 class="title is-4 mb-1">{{ event.name }}</h2>
         <p class="subtitle is-6 has-text-grey">{{ event.date | longDate }}</p>
       </div>
-      <span class="tag is-info is-light">Recordings</span>
+      <div class="events-page__detail-meta">
+        <span class="tag is-info is-light">Recordings</span>
+        <button type="button" class="button is-primary is-small" (click)="openUploadDialog()">
+          Upload
+        </button>
+      </div>
     </div>
 
     @if (videosLoading()) {
@@ -84,6 +89,12 @@
     }
   </section>
 }
+
+<app-upload-dialog
+  [open]="uploadModalOpen()"
+  [preselectedTargetKey]="uploadTargetKey()"
+  (closed)="closeUploadDialog()"
+/>
 
 <div class="modal" [class.is-active]="createModalOpen()">
   <div class="modal-background" (click)="closeCreateModal()"></div>

--- a/src/my-dance.web/src/app/features/events/events.html
+++ b/src/my-dance.web/src/app/features/events/events.html
@@ -1,89 +1,156 @@
-<header class="block">
-  <h1 class="title">Events</h1>
-  <p class="subtitle">Workshops, competitions and showcases — and their recordings.</p>
+<header class="events-page__header">
+  <div>
+    <h1 class="title">Events</h1>
+    <p class="subtitle">Workshops, competitions and showcases, with their recordings.</p>
+  </div>
+  <button type="button" class="button is-primary" (click)="openCreateModal()">Create event</button>
 </header>
 
-<div class="columns">
-  <div class="column is-one-third">
-    <section class="box">
-      <h2 class="title is-5">Create an event</h2>
-      <form [formGroup]="form" (ngSubmit)="createEvent()">
+@if (loading()) {
+  <progress class="progress is-primary" max="100" aria-label="Loading events">
+    Loading&hellip;
+  </progress>
+} @else if (failed()) {
+  <div class="notification is-danger is-light" role="alert">
+    <p class="block">We couldn't load your events.</p>
+    <button type="button" class="button is-danger" (click)="load()">Try again</button>
+  </div>
+} @else if (selected(); as event) {
+  <section class="box events-page__panel events-page__recordings-panel">
+    <div class="events-page__detail-header block">
+      <div>
+        <button type="button" class="button is-light is-small mb-3" (click)="clearSelection()">
+          Back to events
+        </button>
+        <h2 class="title is-4 mb-1">{{ event.name }}</h2>
+        <p class="subtitle is-6 has-text-grey">{{ event.date | longDate }}</p>
+      </div>
+      <span class="tag is-info is-light">Recordings</span>
+    </div>
+
+    @if (videosLoading()) {
+      <progress class="progress is-primary" max="100" aria-label="Loading recordings">
+        Loading&hellip;
+      </progress>
+    } @else if (videosFailed()) {
+      <div class="notification is-danger is-light" role="alert">
+        <p class="block">We couldn't load this event's recordings.</p>
+        <button type="button" class="button is-danger" (click)="select(event)">Try again</button>
+      </div>
+    } @else {
+      <app-video-list
+        [videos]="videos()"
+        [scopeEventId]="event.id ?? ''"
+        emptyMessage="No recordings for this event yet."
+      />
+    }
+  </section>
+} @else {
+  <section
+    class="box events-page__panel events-page__event-list-panel"
+    aria-labelledby="events-list-title"
+  >
+    <div class="events-page__panel-header">
+      <div>
+        <h2 id="events-list-title" class="title is-5 mb-1">Your events</h2>
+        <p class="is-size-7 has-text-grey">{{ items().length }} total</p>
+      </div>
+      @if (items().length > 0) {
+        <span class="tag is-light">{{ upcomingEvents().length }} upcoming</span>
+      }
+    </div>
+
+    @if (items().length === 0) {
+      <div class="content mt-4">
+        <p class="has-text-grey">You don't have access to any events yet.</p>
+        <button type="button" class="button is-primary is-light" (click)="openCreateModal()">
+          Create the first event
+        </button>
+      </div>
+    } @else {
+      @if (upcomingEvents().length > 0) {
+        <h3 class="events-page__section-label">Upcoming</h3>
+        <div class="events-page__list">
+          @for (event of upcomingEvents(); track event.id ?? $index) {
+            <button type="button" class="events-page__event-button" (click)="select(event)">
+              <span>
+                <span class="events-page__event-name">{{ event.name }}</span>
+                <span class="events-page__event-date is-size-7 has-text-grey">
+                  {{ event.date | longDate }}
+                </span>
+              </span>
+              <span class="events-page__event-arrow" aria-hidden="true">&rsaquo;</span>
+            </button>
+          }
+        </div>
+      }
+
+      @if (pastEvents().length > 0) {
+        <h3 class="events-page__section-label">Past</h3>
+        <div class="events-page__list">
+          @for (event of pastEvents(); track event.id ?? $index) {
+            <button type="button" class="events-page__event-button" (click)="select(event)">
+              <span>
+                <span class="events-page__event-name">{{ event.name }}</span>
+                <span class="events-page__event-date is-size-7 has-text-grey">
+                  {{ event.date | longDate }}
+                </span>
+              </span>
+              <span class="events-page__event-arrow" aria-hidden="true">&rsaquo;</span>
+            </button>
+          }
+        </div>
+      }
+    }
+  </section>
+}
+
+<div class="modal" [class.is-active]="createModalOpen()">
+  <div class="modal-background" (click)="closeCreateModal()"></div>
+  <div class="modal-card">
+    <header class="modal-card-head">
+      <p class="modal-card-title">Create an event</p>
+      <button type="button" class="delete" aria-label="close" (click)="closeCreateModal()"></button>
+    </header>
+
+    <form [formGroup]="form" (ngSubmit)="createEvent()">
+      <section class="modal-card-body">
+        @if (createFailed()) {
+          <div class="notification is-danger is-light" role="alert">
+            We couldn't create the event. Check the details and try again.
+          </div>
+        }
+
         <div class="field">
           <label class="label" for="event-name">Name</label>
           <div class="control">
-            <input id="event-name" class="input" type="text" formControlName="name" maxlength="200" />
+            <input
+              id="event-name"
+              class="input"
+              type="text"
+              formControlName="name"
+              maxlength="200"
+              autocomplete="off"
+            />
           </div>
         </div>
+
         <div class="field">
           <label class="label" for="event-date">Date</label>
           <div class="control">
             <input id="event-date" class="input" type="date" formControlName="date" />
           </div>
         </div>
-        <div class="field">
-          <button type="submit" class="button is-primary" [disabled]="form.invalid || creating()">
-            Create event
-          </button>
-        </div>
-      </form>
-    </section>
+      </section>
 
-    <section class="block">
-      <h2 class="title is-5">Your events</h2>
-      @if (loading()) {
-        <progress class="progress is-primary" max="100" aria-label="Loading events">Loading…</progress>
-      } @else if (failed()) {
-        <div class="notification is-danger is-light" role="alert">
-          <p class="block">We couldn’t load your events.</p>
-          <button type="button" class="button is-danger" (click)="load()">Try again</button>
-        </div>
-      } @else if (items().length === 0) {
-        <p class="has-text-grey">You don’t have access to any events yet.</p>
-      } @else {
-        <ul>
-          @for (event of items(); track event.id ?? $index) {
-            <li class="mb-1">
-              <button
-                type="button"
-                class="button is-fullwidth is-justify-content-flex-start"
-                [class.is-link]="selected()?.id === event.id"
-                [class.is-light]="selected()?.id === event.id"
-                [attr.aria-pressed]="selected()?.id === event.id"
-                (click)="select(event)"
-              >
-                <span>
-                  {{ event.name }}
-                  <span class="is-size-7 has-text-grey">· {{ event.date | longDate }}</span>
-                </span>
-              </button>
-            </li>
-          }
-        </ul>
-      }
-    </section>
-  </div>
-
-  <div class="column">
-    @if (selected(); as event) {
-      <h2 class="title is-4">{{ event.name }}</h2>
-      <p class="subtitle is-6 has-text-grey">{{ event.date | longDate }}</p>
-
-      @if (videosLoading()) {
-        <progress class="progress is-primary" max="100" aria-label="Loading recordings">Loading…</progress>
-      } @else if (videosFailed()) {
-        <div class="notification is-danger is-light" role="alert">
-          <p class="block">We couldn’t load this event’s recordings.</p>
-          <button type="button" class="button is-danger" (click)="select(event)">Try again</button>
-        </div>
-      } @else {
-        <app-video-list
-          [videos]="videos()"
-          [scopeEventId]="event.id ?? ''"
-          emptyMessage="No recordings for this event yet."
-        />
-      }
-    } @else {
-      <p class="has-text-grey">Select an event to see its recordings.</p>
-    }
+      <footer class="modal-card-foot events-page__modal-actions">
+        <button type="button" class="button" [disabled]="creating()" (click)="closeCreateModal()">
+          Cancel
+        </button>
+        <button type="submit" class="button is-primary" [disabled]="form.invalid || creating()">
+          {{ creating() ? 'Creating...' : 'Create event' }}
+        </button>
+      </footer>
+    </form>
   </div>
 </div>

--- a/src/my-dance.web/src/app/features/events/events.html
+++ b/src/my-dance.web/src/app/features/events/events.html
@@ -53,11 +53,8 @@
     <div class="events-page__panel-header">
       <div>
         <h2 id="events-list-title" class="title is-5 mb-1">Your events</h2>
-        <p class="is-size-7 has-text-grey">{{ items().length }} total</p>
+        <p class="is-size-7 has-text-grey">{{ items().length }} total events</p>
       </div>
-      @if (items().length > 0) {
-        <span class="tag is-light">{{ upcomingEvents().length }} upcoming</span>
-      }
     </div>
 
     @if (items().length === 0) {
@@ -68,27 +65,10 @@
         </button>
       </div>
     } @else {
-      @if (upcomingEvents().length > 0) {
-        <h3 class="events-page__section-label">Upcoming</h3>
+      @for (group of eventSeasonGroups(); track group.key) {
+        <h3 class="events-page__section-label">{{ group.label }}</h3>
         <div class="events-page__list">
-          @for (event of upcomingEvents(); track event.id ?? $index) {
-            <button type="button" class="events-page__event-button" (click)="select(event)">
-              <span>
-                <span class="events-page__event-name">{{ event.name }}</span>
-                <span class="events-page__event-date is-size-7 has-text-grey">
-                  {{ event.date | longDate }}
-                </span>
-              </span>
-              <span class="events-page__event-arrow" aria-hidden="true">&rsaquo;</span>
-            </button>
-          }
-        </div>
-      }
-
-      @if (pastEvents().length > 0) {
-        <h3 class="events-page__section-label">Past</h3>
-        <div class="events-page__list">
-          @for (event of pastEvents(); track event.id ?? $index) {
+          @for (event of group.events; track event.id ?? $index) {
             <button type="button" class="events-page__event-button" (click)="select(event)">
               <span>
                 <span class="events-page__event-name">{{ event.name }}</span>

--- a/src/my-dance.web/src/app/features/events/events.spec.ts
+++ b/src/my-dance.web/src/app/features/events/events.spec.ts
@@ -6,6 +6,8 @@ import { Events } from './events';
 import { AccessService } from '../../core/api/access.service';
 import { EventsService } from '../../core/api/events.service';
 import { EventModel } from '../../core/api/api-models';
+import { UploadService } from '../../core/api/upload.service';
+import { BlobUploadService } from '../../core/api/blob-upload.service';
 
 const GALA: EventModel = { id: 'e1', name: 'Gala', date: new Date(2026, 0, 1) };
 const WORKSHOP: EventModel = { id: 'e2', name: 'Workshop', date: new Date(2099, 5, 1) };
@@ -22,6 +24,8 @@ function createEventsFixture(overrides: {
     getEventVideos: overrides.getEventVideos ?? vi.fn(() => of({ videos: [] })),
     createEvent: overrides.createEvent ?? vi.fn(() => of({ id: 'new' })),
   };
+  const uploads = { produceUploadUrl: vi.fn(() => of({ sas: '', videoId: 'v' })) };
+  const blob = { upload: vi.fn(() => of(100)) };
 
   TestBed.configureTestingModule({
     imports: [Events],
@@ -29,6 +33,8 @@ function createEventsFixture(overrides: {
       provideRouter([]),
       { provide: AccessService, useValue: access },
       { provide: EventsService, useValue: events },
+      { provide: UploadService, useValue: uploads },
+      { provide: BlobUploadService, useValue: blob },
     ],
   });
 
@@ -137,8 +143,9 @@ describe('Events', () => {
     });
     expect(component.creating()).toBe(false);
     expect(component.createModalOpen()).toBe(false);
-    // load() ran once on init and once after creating.
-    expect(access.getMyAccess).toHaveBeenCalledTimes(2);
+    // Events.load() ran once on init and once after creating;
+    // UploadDialog.loadTargets() also calls getMyAccess once on init.
+    expect(access.getMyAccess).toHaveBeenCalledTimes(3);
   });
 
   it('createEvent() clears the creating flag when the request fails', () => {
@@ -165,5 +172,36 @@ describe('Events', () => {
 
     expect(component.createModalOpen()).toBe(false);
     expect(component.form.getRawValue()).toEqual({ name: '', date: '' });
+  });
+
+  it('openUploadDialog() and closeUploadDialog() toggle the upload modal', () => {
+    const { component } = createEventsFixture({});
+
+    expect(component.uploadModalOpen()).toBe(false);
+    component.openUploadDialog();
+    expect(component.uploadModalOpen()).toBe(true);
+    component.closeUploadDialog();
+    expect(component.uploadModalOpen()).toBe(false);
+  });
+
+  it('uploadTargetKey returns undefined with no selection and the event key when one is selected', () => {
+    const { component } = createEventsFixture({});
+
+    expect(component.uploadTargetKey()).toBeUndefined();
+
+    component.select(GALA);
+    expect(component.uploadTargetKey()).toBe('e:e1');
+  });
+
+  it('clearSelection() also closes the upload dialog', () => {
+    const { component } = createEventsFixture({});
+    component.select(GALA);
+    component.openUploadDialog();
+    expect(component.uploadModalOpen()).toBe(true);
+
+    component.clearSelection();
+
+    expect(component.uploadModalOpen()).toBe(false);
+    expect(component.selected()).toBeNull();
   });
 });

--- a/src/my-dance.web/src/app/features/events/events.spec.ts
+++ b/src/my-dance.web/src/app/features/events/events.spec.ts
@@ -8,6 +8,7 @@ import { EventsService } from '../../core/api/events.service';
 import { EventModel } from '../../core/api/api-models';
 
 const GALA: EventModel = { id: 'e1', name: 'Gala', date: new Date(2026, 0, 1) };
+const WORKSHOP: EventModel = { id: 'e2', name: 'Workshop', date: new Date(2099, 5, 1) };
 
 function createEventsFixture(overrides: {
   getMyAccess?: ReturnType<typeof vi.fn>;
@@ -43,8 +44,19 @@ describe('Events', () => {
     expect(component.items()).toHaveLength(1);
   });
 
+  it('groups events into upcoming and past lists', () => {
+    const { component } = createEventsFixture({
+      getMyAccess: vi.fn(() => of({ assigned: { events: [GALA, WORKSHOP] } })),
+    });
+
+    expect(component.upcomingEvents().map((event) => event.id)).toEqual(['e2']);
+    expect(component.pastEvents().map((event) => event.id)).toEqual(['e1']);
+  });
+
   it('enters the failed state when loading errors', () => {
-    const { component } = createEventsFixture({ getMyAccess: vi.fn(() => throwError(() => new Error('x'))) });
+    const { component } = createEventsFixture({
+      getMyAccess: vi.fn(() => throwError(() => new Error('x'))),
+    });
     expect(component.failed()).toBe(true);
   });
 
@@ -75,6 +87,20 @@ describe('Events', () => {
     expect(component.videosLoading()).toBe(false);
   });
 
+  it('clearSelection() returns to the event list state', () => {
+    const { component } = createEventsFixture({
+      getEventVideos: vi.fn(() => of({ videos: [{ name: 'v1' }] })),
+    });
+
+    component.select(GALA);
+    component.clearSelection();
+
+    expect(component.selected()).toBeNull();
+    expect(component.videos()).toEqual([]);
+    expect(component.videosLoading()).toBe(false);
+    expect(component.videosFailed()).toBe(false);
+  });
+
   it('createEvent() does nothing while the form is invalid', () => {
     const { component, events } = createEventsFixture({});
     component.createEvent();
@@ -85,6 +111,7 @@ describe('Events', () => {
     const createEvent = vi.fn(() => of({ id: 'new' }));
     const { component, access, events } = createEventsFixture({ createEvent });
 
+    component.openCreateModal();
     component.form.setValue({ name: '  Winter Ball  ', date: '2026-02-14' });
     component.createEvent();
 
@@ -92,6 +119,7 @@ describe('Events', () => {
       event: { name: 'Winter Ball', date: new Date('2026-02-14') },
     });
     expect(component.creating()).toBe(false);
+    expect(component.createModalOpen()).toBe(false);
     // load() ran once on init and once after creating.
     expect(access.getMyAccess).toHaveBeenCalledTimes(2);
   });
@@ -100,9 +128,25 @@ describe('Events', () => {
     const createEvent = vi.fn(() => throwError(() => new Error('x')));
     const { component } = createEventsFixture({ createEvent });
 
+    component.openCreateModal();
     component.form.setValue({ name: 'Winter Ball', date: '2026-02-14' });
     component.createEvent();
 
     expect(component.creating()).toBe(false);
+    expect(component.createModalOpen()).toBe(true);
+    expect(component.createFailed()).toBe(true);
+  });
+
+  it('opens and closes the create modal', () => {
+    const { component } = createEventsFixture({});
+
+    component.openCreateModal();
+    expect(component.createModalOpen()).toBe(true);
+
+    component.form.setValue({ name: 'Draft', date: '2026-02-14' });
+    component.closeCreateModal();
+
+    expect(component.createModalOpen()).toBe(false);
+    expect(component.form.getRawValue()).toEqual({ name: '', date: '' });
   });
 });

--- a/src/my-dance.web/src/app/features/events/events.spec.ts
+++ b/src/my-dance.web/src/app/features/events/events.spec.ts
@@ -44,13 +44,30 @@ describe('Events', () => {
     expect(component.items()).toHaveLength(1);
   });
 
-  it('groups events into upcoming and past lists', () => {
+  it('groups events by year and season', () => {
+    const springEvent: EventModel = {
+      id: 'e3',
+      name: 'Spring Intensive',
+      date: new Date(2026, 3, 1),
+    };
+    const autumnEvent: EventModel = { id: 'e4', name: 'Autumn Gala', date: new Date(2025, 9, 1) };
     const { component } = createEventsFixture({
-      getMyAccess: vi.fn(() => of({ assigned: { events: [GALA, WORKSHOP] } })),
+      getMyAccess: vi.fn(() =>
+        of({ assigned: { events: [GALA, springEvent, autumnEvent, WORKSHOP] } }),
+      ),
     });
 
-    expect(component.upcomingEvents().map((event) => event.id)).toEqual(['e2']);
-    expect(component.pastEvents().map((event) => event.id)).toEqual(['e1']);
+    expect(
+      component.eventSeasonGroups().map((group) => ({
+        label: group.label,
+        eventIds: group.events.map((event) => event.id),
+      })),
+    ).toEqual([
+      { label: '2099 Summer', eventIds: ['e2'] },
+      { label: '2026 Spring', eventIds: ['e3'] },
+      { label: '2026 Winter', eventIds: ['e1'] },
+      { label: '2025 Autumn', eventIds: ['e4'] },
+    ]);
   });
 
   it('enters the failed state when loading errors', () => {

--- a/src/my-dance.web/src/app/features/events/events.ts
+++ b/src/my-dance.web/src/app/features/events/events.ts
@@ -14,6 +14,7 @@ import { EventsService } from '../../core/api/events.service';
 import { EventModel, VideoInformation } from '../../core/api/api-models';
 import { LongDatePipe } from '../../shared/format/long-date.pipe';
 import { VideoList } from '../../shared/ui/video-list/video-list';
+import { UploadDialog } from '../upload/upload-dialog';
 
 interface EventSeasonGroup {
   readonly key: string;
@@ -25,7 +26,7 @@ type Season = 'Winter' | 'Spring' | 'Summer' | 'Autumn';
 
 @Component({
   selector: 'app-events',
-  imports: [ReactiveFormsModule, LongDatePipe, VideoList],
+  imports: [ReactiveFormsModule, LongDatePipe, VideoList, UploadDialog],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './events.html',
   styles: `
@@ -123,6 +124,13 @@ type Season = 'Winter' | 'Spring' | 'Summer' | 'Autumn';
       gap: 0.5rem;
     }
 
+    .events-page__detail-meta {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      gap: 0.5rem;
+    }
+
     @media (max-width: 768px) {
       .events-page__header,
       .events-page__panel-header,
@@ -134,6 +142,12 @@ type Season = 'Winter' | 'Spring' | 'Summer' | 'Autumn';
       .events-page__detail-header .button,
       .events-page__detail-header .tag {
         margin-top: 0.75rem;
+      }
+
+      .events-page__detail-meta {
+        flex-direction: row;
+        align-items: center;
+        flex-wrap: wrap;
       }
     }
   `,
@@ -153,6 +167,12 @@ export class Events {
   readonly videos = signal<readonly VideoInformation[]>([]);
   readonly videosLoading = signal(false);
   readonly videosFailed = signal(false);
+
+  readonly uploadModalOpen = signal(false);
+  readonly uploadTargetKey = computed(() => {
+    const event = this.selected();
+    return event?.id ? `e:${event.id}` : undefined;
+  });
 
   readonly creating = signal(false);
   readonly createModalOpen = signal(false);
@@ -210,10 +230,19 @@ export class Events {
   }
 
   clearSelection(): void {
+    this.uploadModalOpen.set(false);
     this.selected.set(null);
     this.videos.set([]);
     this.videosLoading.set(false);
     this.videosFailed.set(false);
+  }
+
+  openUploadDialog(): void {
+    this.uploadModalOpen.set(true);
+  }
+
+  closeUploadDialog(): void {
+    this.uploadModalOpen.set(false);
   }
 
   openCreateModal(): void {

--- a/src/my-dance.web/src/app/features/events/events.ts
+++ b/src/my-dance.web/src/app/features/events/events.ts
@@ -305,6 +305,9 @@ function groupEventsBySeason(events: readonly EventModel[]): readonly EventSeaso
   >();
 
   for (const event of events) {
+    if (!event.date) {
+      continue;
+    }
     const date = toDate(event.date);
     const year = date.getFullYear();
     const season = seasonForMonth(date.getMonth());

--- a/src/my-dance.web/src/app/features/events/events.ts
+++ b/src/my-dance.web/src/app/features/events/events.ts
@@ -15,6 +15,14 @@ import { EventModel, VideoInformation } from '../../core/api/api-models';
 import { LongDatePipe } from '../../shared/format/long-date.pipe';
 import { VideoList } from '../../shared/ui/video-list/video-list';
 
+interface EventSeasonGroup {
+  readonly key: string;
+  readonly label: string;
+  readonly events: readonly EventModel[];
+}
+
+type Season = 'Winter' | 'Spring' | 'Summer' | 'Autumn';
+
 @Component({
   selector: 'app-events',
   imports: [ReactiveFormsModule, LongDatePipe, VideoList],
@@ -139,16 +147,7 @@ export class Events {
   readonly loading = signal(true);
   readonly failed = signal(false);
   readonly items = signal<readonly EventModel[]>([]);
-  readonly upcomingEvents = computed(() =>
-    [...this.items()]
-      .filter((event) => dateValue(event.date) >= todayValue())
-      .sort((a, b) => dateValue(a.date) - dateValue(b.date)),
-  );
-  readonly pastEvents = computed(() =>
-    [...this.items()]
-      .filter((event) => dateValue(event.date) < todayValue())
-      .sort((a, b) => dateValue(b.date) - dateValue(a.date)),
-  );
+  readonly eventSeasonGroups = computed(() => groupEventsBySeason(this.items()));
 
   readonly selected = signal<EventModel | null>(null);
   readonly videos = signal<readonly VideoInformation[]>([]);
@@ -270,8 +269,56 @@ function dateValue(value: Date | string | number | undefined): number {
   return new Date(value).getTime();
 }
 
-function todayValue(): number {
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  return today.getTime();
+function groupEventsBySeason(events: readonly EventModel[]): readonly EventSeasonGroup[] {
+  const groups = new Map<
+    string,
+    { label: string; newestEventDate: number; events: EventModel[] }
+  >();
+
+  for (const event of events) {
+    const date = toDate(event.date);
+    const year = date.getFullYear();
+    const season = seasonForMonth(date.getMonth());
+    const key = `${year}-${season}`;
+    const eventDate = date.getTime();
+    const group = groups.get(key);
+
+    if (group) {
+      group.events.push(event);
+      group.newestEventDate = Math.max(group.newestEventDate, eventDate);
+    } else {
+      groups.set(key, {
+        label: `${year} ${season}`,
+        newestEventDate: eventDate,
+        events: [event],
+      });
+    }
+  }
+
+  return [...groups.entries()]
+    .map(([key, group]) => ({
+      key,
+      label: group.label,
+      newestEventDate: group.newestEventDate,
+      events: group.events.sort((a, b) => dateValue(b.date) - dateValue(a.date)),
+    }))
+    .sort((a, b) => b.newestEventDate - a.newestEventDate)
+    .map(({ key, label, events }) => ({ key, label, events }));
+}
+
+function toDate(value: Date | string | number | undefined): Date {
+  return value ? new Date(value) : new Date(0);
+}
+
+function seasonForMonth(month: number): Season {
+  if (month >= 2 && month <= 4) {
+    return 'Spring';
+  }
+  if (month >= 5 && month <= 7) {
+    return 'Summer';
+  }
+  if (month >= 8 && month <= 10) {
+    return 'Autumn';
+  }
+  return 'Winter';
 }

--- a/src/my-dance.web/src/app/features/events/events.ts
+++ b/src/my-dance.web/src/app/features/events/events.ts
@@ -1,4 +1,11 @@
-import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 
@@ -13,6 +20,115 @@ import { VideoList } from '../../shared/ui/video-list/video-list';
   imports: [ReactiveFormsModule, LongDatePipe, VideoList],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './events.html',
+  styles: `
+    .events-page__header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .events-page__header .subtitle {
+      margin-bottom: 0;
+    }
+
+    .events-page__panel {
+      border: 1px solid color-mix(in srgb, var(--bulma-border) 82%, transparent);
+      border-radius: 8px;
+      box-shadow: 0 0.35rem 1rem rgba(20, 26, 44, 0.06);
+    }
+
+    .events-page__event-list-panel {
+      max-width: 54rem;
+    }
+
+    .events-page__panel-header,
+    .events-page__detail-header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 1rem;
+    }
+
+    .events-page__section-label {
+      margin: 1rem 0 0.5rem;
+      color: var(--bulma-text-weak);
+      font-size: 0.72rem;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .events-page__list {
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    .events-page__recordings-panel {
+      width: 100%;
+    }
+
+    .events-page__event-button {
+      display: flex;
+      width: 100%;
+      min-height: 4.25rem;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.75rem;
+      padding: 0.75rem;
+      border: 1px solid var(--bulma-border);
+      border-radius: 8px;
+      background: var(--bulma-scheme-main);
+      color: inherit;
+      text-align: left;
+      cursor: pointer;
+    }
+
+    .events-page__event-button:hover,
+    .events-page__event-button:focus-visible {
+      border-color: color-mix(in srgb, var(--bulma-primary) 42%, var(--bulma-border));
+      box-shadow: 0 0.45rem 1rem rgba(20, 26, 44, 0.08);
+      outline: none;
+    }
+
+    .events-page__event-name {
+      display: block;
+      font-weight: 800;
+      line-height: 1.25;
+    }
+
+    .events-page__event-date {
+      display: block;
+      margin-top: 0.2rem;
+    }
+
+    .events-page__event-arrow {
+      flex: 0 0 auto;
+      color: var(--bulma-text-weak);
+      font-weight: 800;
+    }
+
+    .events-page__modal-actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 0.5rem;
+    }
+
+    @media (max-width: 768px) {
+      .events-page__header,
+      .events-page__panel-header,
+      .events-page__detail-header {
+        display: block;
+      }
+
+      .events-page__header .button,
+      .events-page__detail-header .button,
+      .events-page__detail-header .tag {
+        margin-top: 0.75rem;
+      }
+    }
+  `,
 })
 export class Events {
   private readonly access = inject(AccessService);
@@ -23,6 +139,16 @@ export class Events {
   readonly loading = signal(true);
   readonly failed = signal(false);
   readonly items = signal<readonly EventModel[]>([]);
+  readonly upcomingEvents = computed(() =>
+    [...this.items()]
+      .filter((event) => dateValue(event.date) >= todayValue())
+      .sort((a, b) => dateValue(a.date) - dateValue(b.date)),
+  );
+  readonly pastEvents = computed(() =>
+    [...this.items()]
+      .filter((event) => dateValue(event.date) < todayValue())
+      .sort((a, b) => dateValue(b.date) - dateValue(a.date)),
+  );
 
   readonly selected = signal<EventModel | null>(null);
   readonly videos = signal<readonly VideoInformation[]>([]);
@@ -30,6 +156,8 @@ export class Events {
   readonly videosFailed = signal(false);
 
   readonly creating = signal(false);
+  readonly createModalOpen = signal(false);
+  readonly createFailed = signal(false);
   readonly form = this.fb.nonNullable.group({
     name: ['', [Validators.required, Validators.maxLength(200)]],
     date: ['', [Validators.required]],
@@ -82,23 +210,68 @@ export class Events {
       });
   }
 
+  clearSelection(): void {
+    this.selected.set(null);
+    this.videos.set([]);
+    this.videosLoading.set(false);
+    this.videosFailed.set(false);
+  }
+
+  openCreateModal(): void {
+    this.createFailed.set(false);
+    this.createModalOpen.set(true);
+  }
+
+  closeCreateModal(): void {
+    if (this.creating()) {
+      return;
+    }
+    this.createFailed.set(false);
+    this.createModalOpen.set(false);
+    this.form.reset({ name: '', date: '' });
+  }
+
   createEvent(): void {
     if (this.form.invalid || this.creating()) {
       return;
     }
     const { name, date } = this.form.getRawValue();
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      this.form.controls.name.setErrors({ required: true });
+      return;
+    }
+
     this.creating.set(true);
+    this.createFailed.set(false);
 
     this.events
-      .createEvent({ event: { name: name.trim(), date: new Date(date) } })
+      .createEvent({ event: { name: trimmedName, date: new Date(date) } })
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: () => {
           this.creating.set(false);
+          this.createModalOpen.set(false);
           this.form.reset({ name: '', date: '' });
           this.load();
         },
-        error: () => this.creating.set(false),
+        error: () => {
+          this.createFailed.set(true);
+          this.creating.set(false);
+        },
       });
   }
+}
+
+function dateValue(value: Date | string | number | undefined): number {
+  if (!value) {
+    return 0;
+  }
+  return new Date(value).getTime();
+}
+
+function todayValue(): number {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return today.getTime();
 }

--- a/src/my-dance.web/src/app/features/home/dashboard/dashboard.html
+++ b/src/my-dance.web/src/app/features/home/dashboard/dashboard.html
@@ -45,26 +45,31 @@
   <section class="block">
     <h2 class="title is-5">Recent activity</h2>
     @if (recent().length === 0) {
-      <p class="has-text-grey">No recordings yet.</p>
+      <div class="notification is-light">
+        <p>No recordings yet. <a routerLink="/videos/upload">Upload your first one</a> to get started.</p>
+      </div>
     } @else {
-      <ul class="menu-list">
+      <nav class="panel" aria-label="Recent recordings">
         @for (video of recent(); track video.videoId ?? video.blobId ?? $index) {
-          <li>
-            @if (video.converted && video.blobId) {
-              <a [routerLink]="['/videos', video.blobId]">
-                {{ video.name }}
-                <span class="has-text-grey is-size-7">· {{ video.recordedDateTime | longDate }}</span>
-              </a>
-            } @else {
-              <span class="is-flex is-align-items-center">
-                {{ video.name }}
-                <span class="has-text-grey is-size-7 ml-1">· {{ video.recordedDateTime | longDate }}</span>
-                <span class="tag is-warning is-light ml-2">Pending</span>
+          @if (video.converted && video.blobId) {
+            <a class="panel-block" [routerLink]="['/videos', video.blobId]">
+              <span class="is-flex is-flex-direction-column is-flex-grow-1 mr-3">
+                <span class="has-text-weight-medium">{{ video.name }}</span>
+                <span class="is-size-7 has-text-grey">{{ video.recordedDateTime | longDate }}</span>
               </span>
-            }
-          </li>
+              <span class="tag is-link is-light">Watch</span>
+            </a>
+          } @else {
+            <div class="panel-block">
+              <span class="is-flex is-flex-direction-column is-flex-grow-1 mr-3">
+                <span class="has-text-weight-medium has-text-grey-dark">{{ video.name }}</span>
+                <span class="is-size-7 has-text-grey">{{ video.recordedDateTime | longDate }}</span>
+              </span>
+              <span class="tag is-warning is-light">Processing</span>
+            </div>
+          }
         }
-      </ul>
+      </nav>
     }
   </section>
 }

--- a/src/my-dance.web/src/app/features/upload/upload-dialog.html
+++ b/src/my-dance.web/src/app/features/upload/upload-dialog.html
@@ -1,0 +1,195 @@
+<div class="modal" [class.is-active]="open()" role="dialog" aria-modal="true" aria-labelledby="upload-dialog-title">
+  <div class="modal-background" (click)="close()"></div>
+  <div class="modal-card">
+    <header class="modal-card-head">
+      <p class="modal-card-title" id="upload-dialog-title">Upload a recording</p>
+      <button
+        type="button"
+        class="delete"
+        aria-label="Close dialog"
+        [disabled]="stage() === 'uploading'"
+        (click)="close()"
+      ></button>
+    </header>
+
+    @switch (stage()) {
+      @case ('uploading') {
+        <section class="modal-card-body">
+          <p class="block">Uploading file {{ currentIndex() }} of {{ total() }}</p>
+          @for (item of uploadItems(); track item.id) {
+            <div class="box">
+              <div class="level is-mobile mb-2">
+                <div class="level-left">
+                  <p class="level-item has-text-weight-semibold">{{ item.fileName }}</p>
+                </div>
+                <div class="level-right">
+                  <p class="level-item is-size-7 has-text-grey">{{ item.progress }}%</p>
+                </div>
+              </div>
+              <progress
+                class="progress"
+                [class.is-primary]="item.status === 'uploading'"
+                [class.is-success]="item.status === 'done'"
+                [class.is-danger]="item.status === 'error'"
+                [value]="item.progress"
+                max="100"
+              >{{ item.progress }}%</progress>
+            </div>
+          }
+        </section>
+        <footer class="modal-card-foot upload-dialog__footer"></footer>
+      }
+      @case ('done') {
+        <section class="modal-card-body">
+          <div class="notification is-success is-light">
+            {{ total() }} recording{{ total() === 1 ? '' : 's' }} uploaded and now being processed.
+            They'll appear once conversion finishes.
+          </div>
+        </section>
+        <footer class="modal-card-foot upload-dialog__footer">
+          <button type="button" class="button is-light" (click)="retryUpload()">Upload more</button>
+          <button type="button" class="button is-success" (click)="close()">Close</button>
+        </footer>
+      }
+      @case ('error') {
+        <section class="modal-card-body">
+          <div class="notification is-danger is-light" role="alert">
+            The upload failed (file {{ currentIndex() }} of {{ total() }}). Please try again.
+          </div>
+        </section>
+        <footer class="modal-card-foot upload-dialog__footer">
+          <button type="button" class="button is-light" (click)="retryUpload()">Try again</button>
+          <button type="button" class="button is-danger" (click)="close()">Close</button>
+        </footer>
+      }
+      @default {
+        <form [formGroup]="form" (ngSubmit)="submit()">
+          <section class="modal-card-body">
+            <div class="field">
+              <label class="label" for="upload-dialog-file">Video file(s)</label>
+              <div class="control">
+                <input
+                  id="upload-dialog-file"
+                  class="input"
+                  type="file"
+                  accept="video/*"
+                  multiple
+                  (change)="onFilesSelected($event)"
+                />
+              </div>
+              @if (files().length > 0) {
+                <ul class="help">
+                  @for (file of files(); track file.name) {
+                    <li>{{ file.name }}</li>
+                  }
+                </ul>
+              }
+            </div>
+
+            @if (singleFile()) {
+              <div class="field">
+                <label class="label" for="upload-dialog-name">
+                  Name <span class="has-text-grey is-size-7">(optional)</span>
+                </label>
+                <div class="control">
+                  <input
+                    id="upload-dialog-name"
+                    class="input"
+                    type="text"
+                    formControlName="name"
+                    maxlength="200"
+                  />
+                </div>
+                <p class="help">Defaults to the file name.</p>
+              </div>
+            }
+
+            <div class="field">
+              <label class="label" for="upload-dialog-date">
+                Recorded date for all videos
+                <span class="has-text-grey is-size-7">(optional)</span>
+              </label>
+              <div class="field has-addons">
+                <div class="control is-expanded">
+                  <input
+                    id="upload-dialog-date"
+                    class="input"
+                    type="date"
+                    formControlName="recordedDate"
+                    [max]="today"
+                    (change)="applyRecordedDateToAll()"
+                  />
+                </div>
+                <div class="control">
+                  <button
+                    type="button"
+                    class="button is-light"
+                    [disabled]="files().length === 0"
+                    (click)="applyRecordedDateToAll()"
+                  >
+                    Apply to all
+                  </button>
+                </div>
+              </div>
+              <p class="help">Use this to set every selected video, or edit individual dates below.</p>
+            </div>
+
+            @if (fileRows().length > 0) {
+              <div class="field">
+                <label class="label">Recorded date per video</label>
+                <div class="box">
+                  @for (file of fileRows(); track file.id; let index = $index) {
+                    <div class="columns is-vcentered is-mobile">
+                      <div class="column">
+                        <p class="has-text-weight-semibold">{{ file.fileName }}</p>
+                      </div>
+                      <div class="column is-narrow">
+                        <input
+                          class="input"
+                          type="date"
+                          [value]="file.recordedDate"
+                          [max]="today"
+                          [attr.aria-label]="'Recorded date for ' + file.fileName"
+                          (change)="onRecordedDateSelected(index, $event)"
+                        />
+                      </div>
+                    </div>
+                  }
+                </div>
+                <p class="help">Blank dates default to each file's last-modified date.</p>
+              </div>
+            }
+
+            <div class="field">
+              <label class="label" for="upload-dialog-target">Upload to</label>
+              <div class="control">
+                <div class="select is-fullwidth">
+                  <select
+                    id="upload-dialog-target"
+                    formControlName="targetKey"
+                    [disabled]="targetsLoading()"
+                  >
+                    @for (target of targets(); track target.key) {
+                      <option [value]="target.key">{{ target.label }}</option>
+                    }
+                  </select>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <footer class="modal-card-foot upload-dialog__footer">
+            <button type="button" class="button" (click)="close()">Cancel</button>
+            <button
+              type="submit"
+              class="button is-primary"
+              [disabled]="form.invalid || !canSubmit()"
+            >
+              Upload
+            </button>
+          </footer>
+        </form>
+      }
+    }
+  </div>
+</div>

--- a/src/my-dance.web/src/app/features/upload/upload-dialog.spec.ts
+++ b/src/my-dance.web/src/app/features/upload/upload-dialog.spec.ts
@@ -1,0 +1,217 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, Subject, throwError } from 'rxjs';
+
+import { UploadDialog } from './upload-dialog';
+import { UploadService } from '../../core/api/upload.service';
+import { BlobUploadService } from '../../core/api/blob-upload.service';
+import { AccessService } from '../../core/api/access.service';
+import { SharingWithType } from '../../core/api/api-models';
+
+function file(name: string): File {
+  return new File([new Uint8Array(1)], name, { type: 'video/mp4' });
+}
+
+function createFixture(overrides: {
+  getMyAccess?: ReturnType<typeof vi.fn>;
+  produceUploadUrl?: ReturnType<typeof vi.fn>;
+  upload?: ReturnType<typeof vi.fn>;
+}) {
+  const access = {
+    getMyAccess:
+      overrides.getMyAccess ??
+      vi.fn(() =>
+        of({
+          assigned: {
+            groups: [{ id: 'g1', name: 'Salsa' }],
+            events: [{ id: 'e1', name: 'Gala', date: new Date(2026, 0, 1) }],
+          },
+        }),
+      ),
+  };
+  const uploads = {
+    produceUploadUrl: overrides.produceUploadUrl ?? vi.fn(() => of({ sas: 'sas-url', videoId: 'v' })),
+  };
+  const blob = { upload: overrides.upload ?? vi.fn(() => of(100)) };
+
+  TestBed.configureTestingModule({
+    imports: [UploadDialog],
+    providers: [
+      { provide: AccessService, useValue: access },
+      { provide: UploadService, useValue: uploads },
+      { provide: BlobUploadService, useValue: blob },
+    ],
+  });
+
+  const fixture: ComponentFixture<UploadDialog> = TestBed.createComponent(UploadDialog);
+  fixture.detectChanges();
+  return { fixture, access, uploads, blob, component: fixture.componentInstance };
+}
+
+describe('UploadDialog', () => {
+  describe('target loading', () => {
+    it('builds targets from assigned groups, events, and the private library', () => {
+      const { component } = createFixture({});
+      const targets = component.targets();
+      expect(targets.map((t) => t.key)).toEqual(['private', 'g:g1', 'e:e1']);
+      expect(targets[1]).toMatchObject({ label: 'Group: Salsa', type: SharingWithType.Group, sharedWith: 'g1' });
+      expect(targets[2]).toMatchObject({ label: 'Event: Gala', type: SharingWithType.Event, sharedWith: 'e1' });
+      expect(component.targetsLoading()).toBe(false);
+    });
+
+    it('stops the targets spinner even when access loading fails', () => {
+      const { component } = createFixture({
+        getMyAccess: vi.fn(() => throwError(() => new Error('x'))),
+      });
+      expect(component.targetsLoading()).toBe(false);
+      expect(component.targets()).toEqual([]);
+    });
+  });
+
+  describe('file selection', () => {
+    it('tracks selected files and sets canSubmit', () => {
+      const { component } = createFixture({});
+      expect(component.canSubmit()).toBe(false);
+
+      component.onFilesSelected({ target: { files: [file('a.mp4')] } } as unknown as Event);
+
+      expect(component.files()).toHaveLength(1);
+      expect(component.canSubmit()).toBe(true);
+      expect(component.singleFile()).toBe(true);
+    });
+  });
+
+  describe('upload flow', () => {
+    it('uploads a file to the private library and reaches the done stage', () => {
+      const { component, uploads, blob } = createFixture({});
+      const f = file('lesson.mp4');
+      component.files.set([f]);
+      component.form.patchValue({ recordedDate: '2026-05-01' });
+
+      component.submit();
+
+      expect(uploads.produceUploadUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nameOfVideo: 'lesson.mp4',
+          sharingWithType: SharingWithType.Private,
+        }),
+      );
+      expect(blob.upload).toHaveBeenCalledWith('sas-url', f);
+      expect(component.stage()).toBe('done');
+    });
+
+    it('targets an event when that target key is selected', () => {
+      const { component, uploads } = createFixture({});
+      component.form.patchValue({ targetKey: 'e:e1', recordedDate: '2026-05-01' });
+      component.files.set([file('lesson.mp4')]);
+
+      component.submit();
+
+      expect(uploads.produceUploadUrl).toHaveBeenCalledWith(
+        expect.objectContaining({ sharingWithType: SharingWithType.Event, sharedWith: 'e1' }),
+      );
+    });
+
+    it('enters the error stage when the upload fails', () => {
+      const { component } = createFixture({
+        produceUploadUrl: vi.fn(() => throwError(() => new Error('fail'))),
+      });
+      component.files.set([file('lesson.mp4')]);
+
+      component.submit();
+
+      expect(component.stage()).toBe('error');
+    });
+  });
+
+  describe('dialog lifecycle', () => {
+    it('opening the dialog resets form state and applies the preselected target key', () => {
+      const { fixture, component } = createFixture({});
+
+      component.files.set([file('old.mp4')]);
+      component.form.patchValue({ name: 'stale', targetKey: 'g:g1' });
+
+      fixture.componentRef.setInput('preselectedTargetKey', 'e:e1');
+      fixture.componentRef.setInput('open', true);
+      fixture.detectChanges();
+
+      expect(component.files()).toEqual([]);
+      expect(component.form.getRawValue()).toEqual({ name: '', recordedDate: '', targetKey: 'e:e1' });
+      expect(component.stage()).toBe('form');
+    });
+
+    it('opening the dialog without a preselected key defaults to the private library', () => {
+      const { fixture, component } = createFixture({});
+
+      fixture.componentRef.setInput('open', true);
+      fixture.detectChanges();
+
+      expect(component.form.getRawValue().targetKey).toBe('private');
+    });
+
+    it('ignores a preselected key that is not in the targets list', () => {
+      const { fixture, component } = createFixture({});
+
+      fixture.componentRef.setInput('preselectedTargetKey', 'e:unknown');
+      fixture.componentRef.setInput('open', true);
+      fixture.detectChanges();
+
+      expect(component.form.getRawValue().targetKey).toBe('private');
+    });
+
+    it('close() emits the closed event and resets state', () => {
+      const { component } = createFixture({});
+      component.files.set([file('video.mp4')]);
+      component.submit();
+      expect(component.stage()).toBe('done');
+
+      let closedEmitted = false;
+      component.closed.subscribe(() => {
+        closedEmitted = true;
+      });
+
+      component.close();
+
+      expect(closedEmitted).toBe(true);
+      expect(component.stage()).toBe('form');
+      expect(component.files()).toEqual([]);
+    });
+
+    it('close() does nothing while upload is in progress', () => {
+      const uploadSubject = new Subject<number>();
+      const { component } = createFixture({ upload: vi.fn(() => uploadSubject) });
+      component.files.set([file('video.mp4')]);
+      component.submit();
+      expect(component.stage()).toBe('uploading');
+
+      let closedEmitted = false;
+      component.closed.subscribe(() => {
+        closedEmitted = true;
+      });
+
+      component.close();
+
+      expect(closedEmitted).toBe(false);
+      expect(component.stage()).toBe('uploading');
+    });
+
+    it('retryUpload() resets to the form and re-applies the preselected key', () => {
+      const { fixture, component } = createFixture({
+        produceUploadUrl: vi.fn(() => throwError(() => new Error('fail'))),
+      });
+
+      fixture.componentRef.setInput('preselectedTargetKey', 'e:e1');
+      fixture.componentRef.setInput('open', true);
+      fixture.detectChanges();
+
+      component.files.set([file('video.mp4')]);
+      component.submit();
+      expect(component.stage()).toBe('error');
+
+      component.retryUpload();
+
+      expect(component.stage()).toBe('form');
+      expect(component.files()).toEqual([]);
+      expect(component.form.getRawValue().targetKey).toBe('e:e1');
+    });
+  });
+});

--- a/src/my-dance.web/src/app/features/upload/upload-dialog.spec.ts
+++ b/src/my-dance.web/src/app/features/upload/upload-dialog.spec.ts
@@ -111,7 +111,7 @@ describe('UploadDialog', () => {
       );
     });
 
-    it('enters the error stage when the upload fails', () => {
+    it('marks the item as error and completes the batch when the upload fails', () => {
       const { component } = createFixture({
         produceUploadUrl: vi.fn(() => throwError(() => new Error('fail'))),
       });
@@ -119,7 +119,8 @@ describe('UploadDialog', () => {
 
       component.submit();
 
-      expect(component.stage()).toBe('error');
+      expect(component.uploadItems()[0]).toMatchObject({ status: 'error' });
+      expect(component.stage()).toBe('done');
     });
   });
 
@@ -205,7 +206,7 @@ describe('UploadDialog', () => {
 
       component.files.set([file('video.mp4')]);
       component.submit();
-      expect(component.stage()).toBe('error');
+      expect(component.stage()).toBe('done');
 
       component.retryUpload();
 

--- a/src/my-dance.web/src/app/features/upload/upload-dialog.ts
+++ b/src/my-dance.web/src/app/features/upload/upload-dialog.ts
@@ -10,7 +10,7 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
-import { concatMap, defer, distinctUntilChanged, filter, from, switchMap, tap } from 'rxjs';
+import { EMPTY, catchError, concatMap, defer, distinctUntilChanged, filter, from, switchMap, tap } from 'rxjs';
 
 import { AccessService } from '../../core/api/access.service';
 import { BlobUploadService } from '../../core/api/blob-upload.service';
@@ -201,6 +201,7 @@ export class UploadDialog {
                   error: () => this.updateUploadItem(index, { status: 'error' }),
                   complete: () => this.updateUploadItem(index, { progress: 100, status: 'done' }),
                 }),
+                catchError(() => EMPTY),
               );
           }),
         ),

--- a/src/my-dance.web/src/app/features/upload/upload-dialog.ts
+++ b/src/my-dance.web/src/app/features/upload/upload-dialog.ts
@@ -1,0 +1,276 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  inject,
+  input,
+  output,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { concatMap, defer, distinctUntilChanged, filter, from, switchMap, tap } from 'rxjs';
+
+import { AccessService } from '../../core/api/access.service';
+import { BlobUploadService } from '../../core/api/blob-upload.service';
+import { UploadService } from '../../core/api/upload.service';
+import { ProduceUploadUrlRequest, SharingWithType } from '../../core/api/api-models';
+
+interface UploadTarget {
+  readonly key: string;
+  readonly label: string;
+  readonly type: SharingWithType;
+  readonly sharedWith?: string;
+}
+
+interface FileRow {
+  readonly id: string;
+  readonly fileName: string;
+  readonly recordedDate: string;
+}
+
+type Stage = 'form' | 'uploading' | 'done' | 'error';
+type UploadItemStatus = 'pending' | 'uploading' | 'done' | 'error';
+
+interface UploadItem {
+  readonly id: string;
+  readonly fileName: string;
+  readonly progress: number;
+  readonly status: UploadItemStatus;
+}
+
+@Component({
+  selector: 'app-upload-dialog',
+  imports: [ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './upload-dialog.html',
+  styles: `
+    .upload-dialog__footer {
+      justify-content: flex-end;
+      gap: 0.5rem;
+    }
+  `,
+})
+export class UploadDialog {
+  private readonly uploads = inject(UploadService);
+  private readonly blob = inject(BlobUploadService);
+  private readonly access = inject(AccessService);
+  private readonly fb = inject(FormBuilder);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly open = input(false);
+  /** Pre-select a target on open, e.g. 'e:<eventId>' or 'g:<groupId>'. */
+  readonly preselectedTargetKey = input<string | undefined>(undefined);
+  readonly closed = output<void>();
+
+  readonly today = new Date().toISOString().slice(0, 10);
+
+  readonly targetsLoading = signal(true);
+  readonly targets = signal<readonly UploadTarget[]>([]);
+
+  readonly stage = signal<Stage>('form');
+  readonly files = signal<readonly File[]>([]);
+  readonly fileRows = signal<readonly FileRow[]>([]);
+  readonly uploadItems = signal<readonly UploadItem[]>([]);
+  readonly total = signal(0);
+  readonly currentIndex = signal(0);
+  readonly progress = signal(0);
+
+  readonly form = this.fb.nonNullable.group({
+    name: ['', [Validators.maxLength(200)]],
+    recordedDate: [''],
+    targetKey: ['private', [Validators.required]],
+  });
+
+  readonly singleFile = computed(() => this.files().length === 1);
+  readonly canSubmit = computed(() => this.files().length > 0);
+
+  constructor() {
+    this.loadTargets();
+
+    toObservable(this.open)
+      .pipe(
+        distinctUntilChanged(),
+        filter((isOpen) => isOpen),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.resetToForm();
+        this.applyPreselectedKey();
+      });
+  }
+
+  loadTargets(): void {
+    this.targetsLoading.set(true);
+    this.access
+      .getMyAccess()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (response) => {
+          const groups = (response.assigned?.groups ?? []).map<UploadTarget>((group) => ({
+            key: `g:${group.id}`,
+            label: `Group: ${group.name}`,
+            type: SharingWithType.Group,
+            sharedWith: group.id ?? '',
+          }));
+          const events = (response.assigned?.events ?? []).map<UploadTarget>((event) => ({
+            key: `e:${event.id}`,
+            label: `Event: ${event.name}`,
+            type: SharingWithType.Event,
+            sharedWith: event.id ?? '',
+          }));
+          this.targets.set([
+            { key: 'private', label: 'Private library', type: SharingWithType.Private },
+            ...groups,
+            ...events,
+          ]);
+          this.targetsLoading.set(false);
+          if (this.open()) {
+            this.applyPreselectedKey();
+          }
+        },
+        error: () => this.targetsLoading.set(false),
+      });
+  }
+
+  onFilesSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const files = input.files ? Array.from(input.files) : [];
+    const recordedDate = this.form.getRawValue().recordedDate;
+    this.files.set(files);
+    this.fileRows.set(files.map((file, index) => this.toFileRow(file, index, recordedDate)));
+    this.uploadItems.set([]);
+  }
+
+  applyRecordedDateToAll(): void {
+    const recordedDate = this.form.getRawValue().recordedDate;
+    this.fileRows.update((rows) => rows.map((row) => ({ ...row, recordedDate })));
+  }
+
+  onRecordedDateSelected(index: number, event: Event): void {
+    const recordedDate = (event.target as HTMLInputElement).value;
+    this.fileRows.update((rows) =>
+      rows.map((row, rowIndex) => (rowIndex === index ? { ...row, recordedDate } : row)),
+    );
+  }
+
+  submit(): void {
+    const files = this.files();
+    if (files.length === 0 || this.form.invalid || this.stage() === 'uploading') {
+      return;
+    }
+
+    const { name, targetKey } = this.form.getRawValue();
+    const target = this.targets().find((option) => option.key === targetKey);
+    if (!target) {
+      return;
+    }
+
+    const explicitName = files.length === 1 ? name.trim() : '';
+
+    this.stage.set('uploading');
+    this.total.set(files.length);
+    this.currentIndex.set(0);
+    this.progress.set(0);
+    this.uploadItems.set(
+      files.map((file, index) => ({
+        id: `${index}:${file.name}:${file.lastModified}:${file.size}`,
+        fileName: file.name,
+        progress: 0,
+        status: 'pending' as UploadItemStatus,
+      })),
+    );
+
+    from(files)
+      .pipe(
+        concatMap((file, index) =>
+          defer(() => {
+            this.currentIndex.set(index + 1);
+            this.progress.set(0);
+            this.updateUploadItem(index, { progress: 0, status: 'uploading' });
+            return this.uploads
+              .produceUploadUrl(this.buildRequest(file, target, explicitName, index))
+              .pipe(
+                switchMap((response) => this.blob.upload(response.sas ?? '', file)),
+                tap({
+                  next: (percent) => {
+                    this.progress.set(percent);
+                    this.updateUploadItem(index, { progress: percent });
+                  },
+                  error: () => this.updateUploadItem(index, { status: 'error' }),
+                  complete: () => this.updateUploadItem(index, { progress: 100, status: 'done' }),
+                }),
+              );
+          }),
+        ),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe({
+        error: () => this.stage.set('error'),
+        complete: () => this.stage.set('done'),
+      });
+  }
+
+  close(): void {
+    if (this.stage() === 'uploading') {
+      return;
+    }
+    this.resetToForm();
+    this.closed.emit();
+  }
+
+  retryUpload(): void {
+    this.resetToForm();
+    this.applyPreselectedKey();
+  }
+
+  private applyPreselectedKey(): void {
+    const key = this.preselectedTargetKey();
+    if (key && this.targets().some((t) => t.key === key)) {
+      this.form.controls.targetKey.setValue(key);
+    }
+  }
+
+  private resetToForm(): void {
+    this.stage.set('form');
+    this.progress.set(0);
+    this.currentIndex.set(0);
+    this.total.set(0);
+    this.files.set([]);
+    this.fileRows.set([]);
+    this.uploadItems.set([]);
+    this.form.reset({ name: '', recordedDate: '', targetKey: 'private' });
+  }
+
+  private updateUploadItem(index: number, patch: Partial<UploadItem>): void {
+    this.uploadItems.update((items) =>
+      items.map((item, itemIndex) => (itemIndex === index ? { ...item, ...patch } : item)),
+    );
+  }
+
+  private toFileRow(file: File, index: number, recordedDate: string): FileRow {
+    return {
+      id: `${index}:${file.name}:${file.lastModified}:${file.size}`,
+      fileName: file.name,
+      recordedDate,
+    };
+  }
+
+  private buildRequest(
+    file: File,
+    target: UploadTarget,
+    explicitName: string,
+    index: number,
+  ): ProduceUploadUrlRequest {
+    const fileRow = this.fileRows()[index];
+    const recordedDate = fileRow ? fileRow.recordedDate : this.form.getRawValue().recordedDate;
+    return {
+      nameOfVideo: explicitName || file.name,
+      fileName: file.name,
+      recordedTimeUtc: recordedDate ? new Date(recordedDate) : new Date(file.lastModified),
+      sharingWithType: target.type,
+      sharedWith: target.sharedWith as string,
+    };
+  }
+}

--- a/src/my-dance.web/src/app/features/upload/upload.html
+++ b/src/my-dance.web/src/app/features/upload/upload.html
@@ -74,12 +74,54 @@
       }
 
       <div class="field">
-        <label class="label" for="upload-date">Recorded date <span class="has-text-grey is-size-7">(optional)</span></label>
-        <div class="control">
-          <input id="upload-date" class="input" type="date" formControlName="recordedDate" [max]="today" />
+        <label class="label" for="upload-date">
+          Recorded date for all videos <span class="has-text-grey is-size-7">(optional)</span>
+        </label>
+        <div class="field has-addons">
+          <div class="control is-expanded">
+            <input
+              id="upload-date"
+              class="input"
+              type="date"
+              formControlName="recordedDate"
+              [max]="today"
+              (change)="applyRecordedDateToAll()"
+            />
+          </div>
+          <div class="control">
+            <button type="button" class="button is-light" [disabled]="files().length === 0" (click)="applyRecordedDateToAll()">
+              Apply to all
+            </button>
+          </div>
         </div>
-        <p class="help">Defaults to each file’s last-modified date.</p>
+        <p class="help">Use this to set every selected video, or edit individual dates below.</p>
       </div>
+
+      @if (fileRows().length > 0) {
+        <div class="field">
+          <label class="label">Recorded date per video</label>
+          <div class="box">
+            @for (file of fileRows(); track file.id; let index = $index) {
+              <div class="columns is-vcentered is-mobile">
+                <div class="column">
+                  <p class="has-text-weight-semibold">{{ file.fileName }}</p>
+                </div>
+                <div class="column is-narrow">
+                  <input
+                    class="input"
+                    type="date"
+                    [value]="file.recordedDate"
+                    [max]="today"
+                    [attr.aria-label]="'Recorded date for ' + file.fileName"
+                    (change)="onRecordedDateSelected(index, $event)"
+                  />
+                </div>
+              </div>
+            }
+          </div>
+          <p class="help">Blank dates default to each file's last-modified date.</p>
+        </div>
+      }
 
       <div class="field">
         <label class="label" for="upload-target">Upload to</label>

--- a/src/my-dance.web/src/app/features/upload/upload.html
+++ b/src/my-dance.web/src/app/features/upload/upload.html
@@ -21,8 +21,30 @@
   }
   @case ('uploading') {
     <div class="block">
-      <p class="block">Uploading file {{ currentIndex() }} of {{ total() }} — {{ progress() }}%</p>
-      <progress class="progress is-primary" [value]="progress()" max="100">{{ progress() }}%</progress>
+      <p class="block">Uploading file {{ currentIndex() }} of {{ total() }}</p>
+
+      @for (item of uploadItems(); track item.id) {
+        <div class="box">
+          <div class="level is-mobile mb-2">
+            <div class="level-left">
+              <p class="level-item has-text-weight-semibold">{{ item.fileName }}</p>
+            </div>
+            <div class="level-right">
+              <p class="level-item is-size-7 has-text-grey">{{ item.progress }}%</p>
+            </div>
+          </div>
+          <progress
+            class="progress"
+            [class.is-primary]="item.status === 'uploading'"
+            [class.is-success]="item.status === 'done'"
+            [class.is-danger]="item.status === 'error'"
+            [value]="item.progress"
+            max="100"
+          >
+            {{ item.progress }}%
+          </progress>
+        </div>
+      }
     </div>
   }
   @default {

--- a/src/my-dance.web/src/app/features/upload/upload.spec.ts
+++ b/src/my-dance.web/src/app/features/upload/upload.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { of, throwError } from 'rxjs';
+import { of, Subject, throwError } from 'rxjs';
 
 import { Upload } from './upload';
 import { UploadService } from '../../core/api/upload.service';
@@ -7,8 +7,12 @@ import { BlobUploadService } from '../../core/api/blob-upload.service';
 import { AccessService } from '../../core/api/access.service';
 import { SharingWithType } from '../../core/api/api-models';
 
-function file(name: string): File {
-  return new File([new Uint8Array(1)], name, { type: 'video/mp4' });
+function file(name: string, lastModified?: number): File {
+  const options: FilePropertyBag = { type: 'video/mp4' };
+  if (lastModified !== undefined) {
+    options.lastModified = lastModified;
+  }
+  return new File([new Uint8Array(1)], name, options);
 }
 
 function createFixture(overrides: {
@@ -70,8 +74,60 @@ describe('Upload', () => {
     component.onFilesSelected({ target: { files: [file('a.mp4')] } } as unknown as Event);
 
     expect(component.files()).toHaveLength(1);
+    expect(component.fileRows()).toEqual([
+      expect.objectContaining({ fileName: 'a.mp4', recordedDate: '' }),
+    ]);
     expect(component.canSubmit()).toBe(true);
     expect(component.singleFile()).toBe(true);
+  });
+
+  it('applies one recorded date to every selected file', () => {
+    const { component } = createFixture({});
+    component.onFilesSelected({ target: { files: [file('one.mp4'), file('two.mp4')] } } as unknown as Event);
+
+    component.form.patchValue({ recordedDate: '2026-05-01' });
+    component.applyRecordedDateToAll();
+
+    expect(component.fileRows()).toEqual([
+      expect.objectContaining({ fileName: 'one.mp4', recordedDate: '2026-05-01' }),
+      expect.objectContaining({ fileName: 'two.mp4', recordedDate: '2026-05-01' }),
+    ]);
+  });
+
+  it('uses per-file recorded date overrides when uploading a batch', () => {
+    const { component, uploads } = createFixture({});
+    component.onFilesSelected({ target: { files: [file('one.mp4'), file('two.mp4')] } } as unknown as Event);
+
+    component.form.patchValue({ recordedDate: '2026-05-01' });
+    component.applyRecordedDateToAll();
+    component.onRecordedDateSelected(1, { target: { value: '2026-05-02' } } as unknown as Event);
+
+    component.submit();
+
+    expect(uploads.produceUploadUrl).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ fileName: 'one.mp4', recordedTimeUtc: new Date('2026-05-01') }),
+    );
+    expect(uploads.produceUploadUrl).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ fileName: 'two.mp4', recordedTimeUtc: new Date('2026-05-02') }),
+    );
+  });
+
+  it('falls back to the file modified date when an individual recorded date is blank', () => {
+    const modified = Date.UTC(2026, 4, 3);
+    const { component, uploads } = createFixture({});
+    component.onFilesSelected({ target: { files: [file('one.mp4', modified)] } } as unknown as Event);
+
+    component.form.patchValue({ recordedDate: '2026-05-01' });
+    component.applyRecordedDateToAll();
+    component.onRecordedDateSelected(0, { target: { value: '' } } as unknown as Event);
+
+    component.submit();
+
+    expect(uploads.produceUploadUrl).toHaveBeenCalledWith(
+      expect.objectContaining({ fileName: 'one.mp4', recordedTimeUtc: new Date(modified) }),
+    );
   });
 
   it('does nothing on submit without files', () => {
@@ -99,6 +155,9 @@ describe('Upload', () => {
     expect(blob.upload).toHaveBeenCalledWith('sas-url', f);
     expect(component.stage()).toBe('done');
     expect(component.progress()).toBe(100);
+    expect(component.uploadItems()).toEqual([
+      expect.objectContaining({ fileName: 'lesson.mp4', progress: 100, status: 'done' }),
+    ]);
     expect(component.total()).toBe(1);
     expect(component.currentIndex()).toBe(1);
   });
@@ -125,6 +184,45 @@ describe('Upload', () => {
     expect(uploads.produceUploadUrl).toHaveBeenCalledTimes(2);
     expect(uploads.produceUploadUrl).toHaveBeenNthCalledWith(1, expect.objectContaining({ nameOfVideo: 'one.mp4' }));
     expect(uploads.produceUploadUrl).toHaveBeenNthCalledWith(2, expect.objectContaining({ nameOfVideo: 'two.mp4' }));
+    expect(component.stage()).toBe('done');
+  });
+
+  it('keeps progress state for every selected file while uploading sequentially', () => {
+    const firstUpload = new Subject<number>();
+    const secondUpload = new Subject<number>();
+    const upload = vi.fn().mockReturnValueOnce(firstUpload).mockReturnValueOnce(secondUpload);
+    const { fixture, component } = createFixture({ upload });
+    component.files.set([file('one.mp4'), file('two.mp4')]);
+
+    component.submit();
+    fixture.detectChanges();
+
+    expect(component.uploadItems()).toEqual([
+      expect.objectContaining({ fileName: 'one.mp4', progress: 0, status: 'uploading' }),
+      expect.objectContaining({ fileName: 'two.mp4', progress: 0, status: 'pending' }),
+    ]);
+    expect((fixture.nativeElement as HTMLElement).querySelectorAll('progress')).toHaveLength(2);
+
+    firstUpload.next(35);
+
+    expect(component.uploadItems()[0]).toEqual(
+      expect.objectContaining({ fileName: 'one.mp4', progress: 35, status: 'uploading' }),
+    );
+
+    firstUpload.complete();
+
+    expect(component.uploadItems()).toEqual([
+      expect.objectContaining({ fileName: 'one.mp4', progress: 100, status: 'done' }),
+      expect.objectContaining({ fileName: 'two.mp4', progress: 0, status: 'uploading' }),
+    ]);
+
+    secondUpload.next(60);
+    secondUpload.complete();
+
+    expect(component.uploadItems()).toEqual([
+      expect.objectContaining({ fileName: 'one.mp4', progress: 100, status: 'done' }),
+      expect.objectContaining({ fileName: 'two.mp4', progress: 100, status: 'done' }),
+    ]);
     expect(component.stage()).toBe('done');
   });
 
@@ -161,7 +259,9 @@ describe('Upload', () => {
 
     expect(component.stage()).toBe('form');
     expect(component.files()).toEqual([]);
+    expect(component.fileRows()).toEqual([]);
     expect(component.progress()).toBe(0);
+    expect(component.uploadItems()).toEqual([]);
     expect(component.total()).toBe(0);
     expect(component.form.getRawValue()).toEqual({ name: '', recordedDate: '', targetKey: 'private' });
   });

--- a/src/my-dance.web/src/app/features/upload/upload.spec.ts
+++ b/src/my-dance.web/src/app/features/upload/upload.spec.ts
@@ -238,7 +238,7 @@ describe('Upload', () => {
     );
   });
 
-  it('enters the error stage when an upload fails', () => {
+  it('marks the item as error and completes the batch when an upload fails', () => {
     const { component } = createFixture({
       produceUploadUrl: vi.fn(() => throwError(() => new Error('nope'))),
     });
@@ -246,7 +246,8 @@ describe('Upload', () => {
 
     component.submit();
 
-    expect(component.stage()).toBe('error');
+    expect(component.uploadItems()[0]).toMatchObject({ status: 'error' });
+    expect(component.stage()).toBe('done');
   });
 
   it('reset returns to the form with cleared state', () => {

--- a/src/my-dance.web/src/app/features/upload/upload.ts
+++ b/src/my-dance.web/src/app/features/upload/upload.ts
@@ -16,6 +16,12 @@ interface UploadTarget {
   readonly sharedWith?: string;
 }
 
+interface FileRow {
+  readonly id: string;
+  readonly fileName: string;
+  readonly recordedDate: string;
+}
+
 type Stage = 'form' | 'uploading' | 'done' | 'error';
 type UploadItemStatus = 'pending' | 'uploading' | 'done' | 'error';
 
@@ -46,6 +52,7 @@ export class Upload {
 
   readonly stage = signal<Stage>('form');
   readonly files = signal<readonly File[]>([]);
+  readonly fileRows = signal<readonly FileRow[]>([]);
   readonly uploadItems = signal<readonly UploadItem[]>([]);
   readonly total = signal(0);
   readonly currentIndex = signal(0);
@@ -96,8 +103,23 @@ export class Upload {
 
   onFilesSelected(event: Event): void {
     const input = event.target as HTMLInputElement;
-    this.files.set(input.files ? Array.from(input.files) : []);
+    const files = input.files ? Array.from(input.files) : [];
+    const recordedDate = this.form.getRawValue().recordedDate;
+    this.files.set(files);
+    this.fileRows.set(files.map((file, index) => this.toFileRow(file, index, recordedDate)));
     this.uploadItems.set([]);
+  }
+
+  applyRecordedDateToAll(): void {
+    const recordedDate = this.form.getRawValue().recordedDate;
+    this.fileRows.update((rows) => rows.map((row) => ({ ...row, recordedDate })));
+  }
+
+  onRecordedDateSelected(index: number, event: Event): void {
+    const recordedDate = (event.target as HTMLInputElement).value;
+    this.fileRows.update((rows) =>
+      rows.map((row, rowIndex) => (rowIndex === index ? { ...row, recordedDate } : row)),
+    );
   }
 
   submit(): void {
@@ -136,7 +158,7 @@ export class Upload {
             this.currentIndex.set(index + 1);
             this.progress.set(0);
             this.updateUploadItem(index, { progress: 0, status: 'uploading' });
-            return this.uploads.produceUploadUrl(this.buildRequest(file, target, explicitName)).pipe(
+            return this.uploads.produceUploadUrl(this.buildRequest(file, target, explicitName, index)).pipe(
               switchMap((response) => this.blob.upload(response.sas ?? '', file)),
               tap({
                 next: (percent) => {
@@ -163,6 +185,7 @@ export class Upload {
     this.currentIndex.set(0);
     this.total.set(0);
     this.files.set([]);
+    this.fileRows.set([]);
     this.uploadItems.set([]);
     this.form.reset({ name: '', recordedDate: '', targetKey: 'private' });
   }
@@ -173,8 +196,22 @@ export class Upload {
     );
   }
 
-  private buildRequest(file: File, target: UploadTarget, explicitName: string): ProduceUploadUrlRequest {
-    const recordedDate = this.form.getRawValue().recordedDate;
+  private toFileRow(file: File, index: number, recordedDate: string): FileRow {
+    return {
+      id: `${index}:${file.name}:${file.lastModified}:${file.size}`,
+      fileName: file.name,
+      recordedDate,
+    };
+  }
+
+  private buildRequest(
+    file: File,
+    target: UploadTarget,
+    explicitName: string,
+    index: number,
+  ): ProduceUploadUrlRequest {
+    const fileRow = this.fileRows()[index];
+    const recordedDate = fileRow ? fileRow.recordedDate : this.form.getRawValue().recordedDate;
     return {
       nameOfVideo: explicitName || file.name,
       fileName: file.name,

--- a/src/my-dance.web/src/app/features/upload/upload.ts
+++ b/src/my-dance.web/src/app/features/upload/upload.ts
@@ -17,6 +17,14 @@ interface UploadTarget {
 }
 
 type Stage = 'form' | 'uploading' | 'done' | 'error';
+type UploadItemStatus = 'pending' | 'uploading' | 'done' | 'error';
+
+interface UploadItem {
+  readonly id: string;
+  readonly fileName: string;
+  readonly progress: number;
+  readonly status: UploadItemStatus;
+}
 
 @Component({
   selector: 'app-upload',
@@ -38,6 +46,7 @@ export class Upload {
 
   readonly stage = signal<Stage>('form');
   readonly files = signal<readonly File[]>([]);
+  readonly uploadItems = signal<readonly UploadItem[]>([]);
   readonly total = signal(0);
   readonly currentIndex = signal(0);
   readonly progress = signal(0);
@@ -88,6 +97,7 @@ export class Upload {
   onFilesSelected(event: Event): void {
     const input = event.target as HTMLInputElement;
     this.files.set(input.files ? Array.from(input.files) : []);
+    this.uploadItems.set([]);
   }
 
   submit(): void {
@@ -110,6 +120,14 @@ export class Upload {
     this.total.set(files.length);
     this.currentIndex.set(0);
     this.progress.set(0);
+    this.uploadItems.set(
+      files.map((file, index) => ({
+        id: `${index}:${file.name}:${file.lastModified}:${file.size}`,
+        fileName: file.name,
+        progress: 0,
+        status: 'pending',
+      })),
+    );
 
     from(files)
       .pipe(
@@ -117,9 +135,17 @@ export class Upload {
           defer(() => {
             this.currentIndex.set(index + 1);
             this.progress.set(0);
+            this.updateUploadItem(index, { progress: 0, status: 'uploading' });
             return this.uploads.produceUploadUrl(this.buildRequest(file, target, explicitName)).pipe(
               switchMap((response) => this.blob.upload(response.sas ?? '', file)),
-              tap((percent) => this.progress.set(percent)),
+              tap({
+                next: (percent) => {
+                  this.progress.set(percent);
+                  this.updateUploadItem(index, { progress: percent });
+                },
+                error: () => this.updateUploadItem(index, { status: 'error' }),
+                complete: () => this.updateUploadItem(index, { progress: 100, status: 'done' }),
+              }),
             );
           }),
         ),
@@ -137,7 +163,14 @@ export class Upload {
     this.currentIndex.set(0);
     this.total.set(0);
     this.files.set([]);
+    this.uploadItems.set([]);
     this.form.reset({ name: '', recordedDate: '', targetKey: 'private' });
+  }
+
+  private updateUploadItem(index: number, patch: Partial<UploadItem>): void {
+    this.uploadItems.update((items) =>
+      items.map((item, itemIndex) => (itemIndex === index ? { ...item, ...patch } : item)),
+    );
   }
 
   private buildRequest(file: File, target: UploadTarget, explicitName: string): ProduceUploadUrlRequest {

--- a/src/my-dance.web/src/app/features/upload/upload.ts
+++ b/src/my-dance.web/src/app/features/upload/upload.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, DestroyRef, computed, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
-import { concatMap, defer, from, switchMap, tap } from 'rxjs';
+import { EMPTY, catchError, concatMap, defer, from, switchMap, tap } from 'rxjs';
 
 import { AccessService } from '../../core/api/access.service';
 import { BlobUploadService } from '../../core/api/blob-upload.service';
@@ -168,6 +168,7 @@ export class Upload {
                 error: () => this.updateUploadItem(index, { status: 'error' }),
                 complete: () => this.updateUploadItem(index, { progress: 100, status: 'done' }),
               }),
+              catchError(() => EMPTY),
             );
           }),
         ),

--- a/src/my-dance.web/src/app/features/videos/group-videos.html
+++ b/src/my-dance.web/src/app/features/videos/group-videos.html
@@ -1,7 +1,15 @@
-<header class="block">
-  <h1 class="title">Lesson recordings</h1>
-  <p class="subtitle">Recordings from your regular groups, newest first.</p>
+<header class="group-videos__header">
+  <div>
+    <h1 class="title">Lesson recordings</h1>
+    <p class="subtitle">Recordings from your regular groups, newest first.</p>
+  </div>
+  <button type="button" class="button is-primary" (click)="openUploadDialog()">Upload</button>
 </header>
+
+<app-upload-dialog
+  [open]="uploadModalOpen()"
+  (closed)="closeUploadDialog()"
+/>
 
 @if (loading()) {
   <progress class="progress is-primary" max="100" aria-label="Loading recordings">Loading…</progress>

--- a/src/my-dance.web/src/app/features/videos/group-videos.html
+++ b/src/my-dance.web/src/app/features/videos/group-videos.html
@@ -1,6 +1,6 @@
 <header class="block">
   <h1 class="title">Lesson recordings</h1>
-  <p class="subtitle">Recordings from your regular groups.</p>
+  <p class="subtitle">Recordings from your regular groups, newest first.</p>
 </header>
 
 @if (loading()) {
@@ -10,23 +10,21 @@
     <p class="block">We couldn’t load the recordings.</p>
     <button type="button" class="button is-danger" (click)="load()">Try again</button>
   </div>
-} @else if (sections().length === 0) {
+} @else if (sortedVideos().length === 0) {
   <div class="notification is-info is-light">
     <p class="block">It looks like you don’t have access to any group recordings yet.</p>
     <a class="button is-info" routerLink="/videos/requestassignment">Request access</a>
   </div>
 } @else {
-  @for (section of sections(); track section.groupId) {
-    <section class="block">
-      <h2 class="title is-4">
-        {{ section.groupName }}
-        @if (section.seasonStart) {
-          <span class="subtitle is-6 has-text-grey ml-2">
-            {{ section.seasonStart | season: section.seasonEnd }}
-          </span>
-        }
-      </h2>
-      <app-video-list [videos]="section.videos" [scopeGroupId]="section.groupId" />
-    </section>
-  }
+  <div class="columns is-multiline">
+    @for (video of sortedVideos(); track video.videoId ?? video.blobId ?? $index) {
+      <div class="column is-one-third-desktop is-half-tablet">
+        <app-video-card
+          [video]="video"
+          [badge]="video.groupName ?? ''"
+          [queryParams]="video.groupId ? { groupId: video.groupId } : {}"
+        />
+      </div>
+    }
+  </div>
 }

--- a/src/my-dance.web/src/app/features/videos/group-videos.spec.ts
+++ b/src/my-dance.web/src/app/features/videos/group-videos.spec.ts
@@ -4,19 +4,16 @@ import { Observable, of, throwError } from 'rxjs';
 
 import { GroupVideos } from './group-videos';
 import { GroupsService } from '../../core/api/groups.service';
-import { AccessService } from '../../core/api/access.service';
-import { ListGroupVideosResponse, GetUserAccessResponse } from '../../core/api/api-models';
+import { ListGroupVideosResponse } from '../../core/api/api-models';
 
 async function setup(opts: {
   videos?: Observable<ListGroupVideosResponse>;
-  access?: Observable<GetUserAccessResponse>;
 }): Promise<ComponentFixture<GroupVideos>> {
   await TestBed.configureTestingModule({
     imports: [GroupVideos],
     providers: [
       provideRouter([]),
       { provide: GroupsService, useValue: { getGroupVideos: () => opts.videos ?? of({ videos: [] }) } },
-      { provide: AccessService, useValue: { getMyAccess: () => opts.access ?? of({}) } },
     ],
   }).compileComponents();
 
@@ -25,44 +22,55 @@ async function setup(opts: {
   return fixture;
 }
 
+function d(y: number, m: number, day: number): Date {
+  return new Date(y, m, day);
+}
+
 describe('GroupVideos', () => {
-  it('buckets videos by group in first-seen order and attaches seasons', async () => {
-    const seasonStart = new Date(2023, 8, 1);
-    const seasonEnd = new Date(2024, 4, 1);
+  it('flattens videos and sorts by recordedDateTime descending across groups', async () => {
     const c = (
       await setup({
         videos: of({
           videos: [
-            { videoId: 'v1', groupId: 'g1', groupName: 'Salsa' },
-            { videoId: 'v2', groupId: 'g2', groupName: 'Bachata' },
-            { videoId: 'v3', groupId: 'g1', groupName: 'Salsa' },
+            { videoId: 'v1', groupId: 'g1', groupName: 'Salsa', recordedDateTime: d(2026, 0, 10) },
+            { videoId: 'v2', groupId: 'g2', groupName: 'Bachata', recordedDateTime: d(2026, 2, 1) },
+            { videoId: 'v3', groupId: 'g1', groupName: 'Salsa', recordedDateTime: d(2026, 1, 15) },
           ],
-        }),
-        access: of({
-          assigned: { groups: [{ id: 'g1', seasonStart, seasonEnd }] },
-          available: { groups: [{ id: 'g2', seasonStart: new Date(2022, 8, 1) }] },
         }),
       })
     ).componentInstance;
 
-    const sections = c.sections();
-    expect(sections.map((s) => s.groupId)).toEqual(['g1', 'g2']);
-    expect(sections[0].videos).toHaveLength(2);
-    expect(sections[0].seasonStart).toEqual(seasonStart);
-    expect(sections[0].seasonEnd).toEqual(seasonEnd);
-    expect(sections[1].videos).toHaveLength(1);
+    expect(c.sortedVideos().map((v) => v.videoId)).toEqual(['v2', 'v3', 'v1']);
   });
 
-  it('falls back to "unknown" group id and "Group" name for ungrouped videos', async () => {
+  it('sinks videos without a recordedDateTime to the end of the list', async () => {
     const c = (
-      await setup({ videos: of({ videos: [{ videoId: 'v1' }] }) })
+      await setup({
+        videos: of({
+          videos: [
+            { videoId: 'no-date' },
+            { videoId: 'old', recordedDateTime: d(2024, 5, 1) },
+            { videoId: 'new', recordedDateTime: d(2026, 5, 1) },
+          ],
+        }),
+      })
     ).componentInstance;
 
-    const sections = c.sections();
-    expect(sections).toHaveLength(1);
-    expect(sections[0].groupId).toBe('unknown');
-    expect(sections[0].groupName).toBe('Group');
-    expect(sections[0].seasonStart).toBeUndefined();
+    expect(c.sortedVideos().map((v) => v.videoId)).toEqual(['new', 'old', 'no-date']);
+  });
+
+  it('keeps group identity on each video so the card can render a badge and group-scoped link', async () => {
+    const c = (
+      await setup({
+        videos: of({
+          videos: [{ videoId: 'v1', groupId: 'g1', groupName: 'Salsa', recordedDateTime: d(2026, 5, 1) }],
+        }),
+      })
+    ).componentInstance;
+
+    const [video] = c.sortedVideos();
+    expect(video.groupId).toBe('g1');
+    expect(video.groupName).toBe('Salsa');
   });
 
   it('enters the failed state on error', async () => {

--- a/src/my-dance.web/src/app/features/videos/group-videos.spec.ts
+++ b/src/my-dance.web/src/app/features/videos/group-videos.spec.ts
@@ -4,6 +4,9 @@ import { Observable, of, throwError } from 'rxjs';
 
 import { GroupVideos } from './group-videos';
 import { GroupsService } from '../../core/api/groups.service';
+import { AccessService } from '../../core/api/access.service';
+import { UploadService } from '../../core/api/upload.service';
+import { BlobUploadService } from '../../core/api/blob-upload.service';
 import { ListGroupVideosResponse } from '../../core/api/api-models';
 
 async function setup(opts: {
@@ -14,6 +17,9 @@ async function setup(opts: {
     providers: [
       provideRouter([]),
       { provide: GroupsService, useValue: { getGroupVideos: () => opts.videos ?? of({ videos: [] }) } },
+      { provide: AccessService, useValue: { getMyAccess: vi.fn(() => of({ assigned: { groups: [], events: [] } })) } },
+      { provide: UploadService, useValue: { produceUploadUrl: vi.fn(() => of({ sas: '', videoId: 'v' })) } },
+      { provide: BlobUploadService, useValue: { upload: vi.fn(() => of(100)) } },
     ],
   }).compileComponents();
 
@@ -77,5 +83,15 @@ describe('GroupVideos', () => {
     const c = (await setup({ videos: throwError(() => new Error('boom')) })).componentInstance;
     expect(c.failed()).toBe(true);
     expect(c.loading()).toBe(false);
+  });
+
+  it('openUploadDialog() and closeUploadDialog() toggle the upload modal', async () => {
+    const component = (await setup({})).componentInstance;
+
+    expect(component.uploadModalOpen()).toBe(false);
+    component.openUploadDialog();
+    expect(component.uploadModalOpen()).toBe(true);
+    component.closeUploadDialog();
+    expect(component.uploadModalOpen()).toBe(false);
   });
 });

--- a/src/my-dance.web/src/app/features/videos/group-videos.ts
+++ b/src/my-dance.web/src/app/features/videos/group-videos.ts
@@ -1,61 +1,38 @@
 import { ChangeDetectionStrategy, Component, DestroyRef, computed, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { forkJoin } from 'rxjs';
 
 import { RouterLink } from '@angular/router';
 
-import { AccessService } from '../../core/api/access.service';
 import { GroupsService } from '../../core/api/groups.service';
-import { GroupModel, VideoFromGroupInformation } from '../../core/api/api-models';
-import { SeasonPipe } from '../../shared/format/season.pipe';
-import { VideoList } from '../../shared/ui/video-list/video-list';
+import { VideoFromGroupInformation } from '../../core/api/api-models';
+import { VideoCard } from '../../shared/ui/video-card/video-card';
 
-interface GroupSection {
-  readonly groupId: string;
-  readonly groupName: string;
-  readonly seasonStart?: Date;
-  readonly seasonEnd?: Date;
-  readonly videos: VideoFromGroupInformation[];
+function recordedTime(video: VideoFromGroupInformation): number {
+  if (!video.recordedDateTime) {
+    return -Infinity;
+  }
+  const time = new Date(video.recordedDateTime).getTime();
+  return Number.isNaN(time) ? -Infinity : time;
 }
 
 @Component({
   selector: 'app-group-videos',
-  imports: [RouterLink, SeasonPipe, VideoList],
+  imports: [RouterLink, VideoCard],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './group-videos.html',
 })
 export class GroupVideos {
   private readonly groups = inject(GroupsService);
-  private readonly access = inject(AccessService);
   private readonly destroyRef = inject(DestroyRef);
 
   readonly loading = signal(true);
   readonly failed = signal(false);
   private readonly items = signal<readonly VideoFromGroupInformation[]>([]);
-  private readonly seasons = signal<ReadonlyMap<string, GroupModel>>(new Map());
 
-  /** Recordings bucketed by their group (with season), preserving first-seen order. */
-  readonly sections = computed<GroupSection[]>(() => {
-    const seasons = this.seasons();
-    const byGroup = new Map<string, GroupSection>();
-    for (const video of this.items()) {
-      const groupId = video.groupId ?? 'unknown';
-      let section = byGroup.get(groupId);
-      if (!section) {
-        const season = seasons.get(groupId);
-        section = {
-          groupId,
-          groupName: video.groupName ?? 'Group',
-          seasonStart: season?.seasonStart,
-          seasonEnd: season?.seasonEnd,
-          videos: [],
-        };
-        byGroup.set(groupId, section);
-      }
-      section.videos.push(video);
-    }
-    return [...byGroup.values()];
-  });
+  /** All lesson recordings, newest first; undated recordings sink to the end. */
+  readonly sortedVideos = computed<readonly VideoFromGroupInformation[]>(() =>
+    [...this.items()].sort((a, b) => recordedTime(b) - recordedTime(a)),
+  );
 
   constructor() {
     this.load();
@@ -65,16 +42,12 @@ export class GroupVideos {
     this.loading.set(true);
     this.failed.set(false);
 
-    forkJoin({
-      videos: this.groups.getGroupVideos(),
-      access: this.access.getMyAccess(),
-    })
+    this.groups
+      .getGroupVideos()
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: ({ videos, access }) => {
-          this.items.set(videos.videos ?? []);
-          const all = [...(access.assigned?.groups ?? []), ...(access.available?.groups ?? [])];
-          this.seasons.set(new Map(all.filter((g) => g.id).map((g) => [g.id as string, g])));
+        next: (response) => {
+          this.items.set(response.videos ?? []);
           this.loading.set(false);
         },
         error: () => {

--- a/src/my-dance.web/src/app/features/videos/group-videos.ts
+++ b/src/my-dance.web/src/app/features/videos/group-videos.ts
@@ -6,6 +6,7 @@ import { RouterLink } from '@angular/router';
 import { GroupsService } from '../../core/api/groups.service';
 import { VideoFromGroupInformation } from '../../core/api/api-models';
 import { VideoCard } from '../../shared/ui/video-card/video-card';
+import { UploadDialog } from '../upload/upload-dialog';
 
 function recordedTime(video: VideoFromGroupInformation): number {
   if (!video.recordedDateTime) {
@@ -17,9 +18,27 @@ function recordedTime(video: VideoFromGroupInformation): number {
 
 @Component({
   selector: 'app-group-videos',
-  imports: [RouterLink, VideoCard],
+  imports: [RouterLink, VideoCard, UploadDialog],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './group-videos.html',
+  styles: `
+    .group-videos__header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+    }
+
+    @media (max-width: 768px) {
+      .group-videos__header {
+        display: block;
+      }
+      .group-videos__header .button {
+        margin-top: 0.75rem;
+      }
+    }
+  `,
 })
 export class GroupVideos {
   private readonly groups = inject(GroupsService);
@@ -27,6 +46,7 @@ export class GroupVideos {
 
   readonly loading = signal(true);
   readonly failed = signal(false);
+  readonly uploadModalOpen = signal(false);
   private readonly items = signal<readonly VideoFromGroupInformation[]>([]);
 
   /** All lesson recordings, newest first; undated recordings sink to the end. */
@@ -36,6 +56,14 @@ export class GroupVideos {
 
   constructor() {
     this.load();
+  }
+
+  openUploadDialog(): void {
+    this.uploadModalOpen.set(true);
+  }
+
+  closeUploadDialog(): void {
+    this.uploadModalOpen.set(false);
   }
 
   load(): void {

--- a/src/my-dance.web/src/app/features/videos/video-player.html
+++ b/src/my-dance.web/src/app/features/videos/video-player.html
@@ -19,7 +19,12 @@
           />
         </div>
         <div class="control">
-          <button type="button" class="button is-primary" [disabled]="renaming()" (click)="saveRename()">
+          <button
+            type="button"
+            class="button is-primary"
+            [disabled]="renaming()"
+            (click)="saveRename()"
+          >
             Save
           </button>
         </div>
@@ -51,11 +56,13 @@
   @if (streamUrl(); as src) {
     <video
       class="is-block"
-      style="width: 100%; max-height: 70vh; background: #000;"
+      style="width: 100%; max-height: 70vh; background: #000"
       controls
+      controlsList="nodownload"
       preload="metadata"
       [src]="src"
       [attr.aria-label]="'Recording: ' + video.name"
+      (contextmenu)="$event.preventDefault()"
     >
       Your browser doesn’t support embedded video.
     </video>
@@ -80,7 +87,12 @@
               (keydown.enter)="setTab('recordings')"
               (keydown.space)="$event.preventDefault(); setTab('recordings')"
             >
-              More from this @if (groupId()) { group } @else { event }
+              More from this
+              @if (groupId()) {
+                group
+              } @else {
+                event
+              }
               <span class="tag is-light ml-2">{{ siblings().length }}</span>
             </a>
           </li>

--- a/src/my-dance.web/src/app/features/videos/video-player.html
+++ b/src/my-dance.web/src/app/features/videos/video-player.html
@@ -48,40 +48,65 @@
     </p>
   </header>
 
-  <div class="columns">
-    <div class="column">
-      @if (streamUrl(); as src) {
-        <video
-          class="is-block"
-          style="width: 100%; max-height: 70vh; background: #000;"
-          controls
-          preload="metadata"
-          [src]="src"
-          [attr.aria-label]="'Recording: ' + video.name"
-        >
-          Your browser doesn’t support embedded video.
-        </video>
-      } @else {
-        <div class="notification is-warning is-light">
-          This recording is still processing and isn’t playable yet. Check back shortly.
-        </div>
-      }
-
-      <app-comments-section
-        class="block mt-5"
-        [comments]="commentList()"
-        [canCompose]="false"
-        (saveEdit)="onSaveEdit($event)"
-        (remove)="onRemove($event)"
-        (hide)="onHide($event)"
-        (unhide)="onUnhide($event)"
-        (report)="onReport($event)"
-      />
+  @if (streamUrl(); as src) {
+    <video
+      class="is-block"
+      style="width: 100%; max-height: 70vh; background: #000;"
+      controls
+      preload="metadata"
+      [src]="src"
+      [attr.aria-label]="'Recording: ' + video.name"
+    >
+      Your browser doesn’t support embedded video.
+    </video>
+  } @else {
+    <div class="notification is-warning is-light">
+      This recording is still processing and isn’t playable yet. Check back shortly.
     </div>
+  }
 
-    @if (siblings().length > 0) {
-      <div class="column is-one-third">
-        <h2 class="title is-6">More from this @if (groupId()) { group } @else { event }</h2>
+  @if (siblings().length > 0) {
+    <div class="block mt-5">
+      <div class="tabs is-boxed">
+        <ul role="tablist">
+          <li role="presentation" [class.is-active]="activeTab() === 'recordings'">
+            <a
+              role="tab"
+              id="tab-recordings"
+              tabindex="0"
+              aria-controls="panel-recordings"
+              [attr.aria-selected]="activeTab() === 'recordings'"
+              (click)="setTab('recordings')"
+              (keydown.enter)="setTab('recordings')"
+              (keydown.space)="$event.preventDefault(); setTab('recordings')"
+            >
+              More from this @if (groupId()) { group } @else { event }
+              <span class="tag is-light ml-2">{{ siblings().length }}</span>
+            </a>
+          </li>
+          <li role="presentation" [class.is-active]="activeTab() === 'comments'">
+            <a
+              role="tab"
+              id="tab-comments"
+              tabindex="0"
+              aria-controls="panel-comments"
+              [attr.aria-selected]="activeTab() === 'comments'"
+              (click)="setTab('comments')"
+              (keydown.enter)="setTab('comments')"
+              (keydown.space)="$event.preventDefault(); setTab('comments')"
+            >
+              Comments
+            </a>
+          </li>
+        </ul>
+      </div>
+
+      <div
+        id="panel-recordings"
+        role="tabpanel"
+        aria-labelledby="tab-recordings"
+        [hidden]="activeTab() !== 'recordings'"
+      >
         <app-video-list
           [videos]="siblings()"
           [scopeGroupId]="groupId()"
@@ -89,8 +114,36 @@
           [selectedBlobId]="blobId()"
         />
       </div>
-    }
-  </div>
+
+      <div
+        id="panel-comments"
+        role="tabpanel"
+        aria-labelledby="tab-comments"
+        [hidden]="activeTab() !== 'comments'"
+      >
+        <app-comments-section
+          [comments]="commentList()"
+          [canCompose]="false"
+          (saveEdit)="onSaveEdit($event)"
+          (remove)="onRemove($event)"
+          (hide)="onHide($event)"
+          (unhide)="onUnhide($event)"
+          (report)="onReport($event)"
+        />
+      </div>
+    </div>
+  } @else {
+    <app-comments-section
+      class="block mt-5"
+      [comments]="commentList()"
+      [canCompose]="false"
+      (saveEdit)="onSaveEdit($event)"
+      (remove)="onRemove($event)"
+      (hide)="onHide($event)"
+      (unhide)="onUnhide($event)"
+      (report)="onReport($event)"
+    />
+  }
 } @else {
   <p class="has-text-grey">Recording not found.</p>
 }

--- a/src/my-dance.web/src/app/features/videos/video-player.spec.ts
+++ b/src/my-dance.web/src/app/features/videos/video-player.spec.ts
@@ -164,6 +164,25 @@ describe('VideoPlayer', () => {
     });
   });
 
+  describe('sidebar tabs', () => {
+    it('defaults to the recordings tab when siblings are loaded', () => {
+      const { component } = createFixture({ groupId: 'g1', getVideosForGroup: vi.fn(() => of({ videos: [{ videoId: 'a' }] })) });
+      expect(component.activeTab()).toBe('recordings');
+    });
+
+    it('switches to the comments tab when requested', () => {
+      const { component } = createFixture({ groupId: 'g1', getVideosForGroup: vi.fn(() => of({ videos: [{ videoId: 'a' }] })) });
+      component.setTab('comments');
+      expect(component.activeTab()).toBe('comments');
+    });
+
+    it('falls back to comments when no siblings are loaded', () => {
+      const { component } = createFixture({});
+      expect(component.siblings()).toHaveLength(0);
+      expect(component.activeTab()).toBe('comments');
+    });
+  });
+
   describe('comment moderation', () => {
     it('edits a comment then reloads the list', () => {
       const { component, comments } = createFixture({});

--- a/src/my-dance.web/src/app/features/videos/video-player.spec.ts
+++ b/src/my-dance.web/src/app/features/videos/video-player.spec.ts
@@ -77,14 +77,25 @@ describe('VideoPlayer', () => {
     expect(component.loading()).toBe(false);
   });
 
+  it('hides the native video download control', () => {
+    const { fixture } = createFixture({});
+    const video = fixture.nativeElement.querySelector('video') as HTMLVideoElement;
+
+    expect(video.getAttribute('controlsList')).toBe('nodownload');
+  });
+
   it('does not expose a stream url for an unconverted recording', () => {
-    const { component, videos } = createFixture({ video: { videoId: 'vid1', blobId: 'blob1', converted: false } });
+    const { component, videos } = createFixture({
+      video: { videoId: 'vid1', blobId: 'blob1', converted: false },
+    });
     expect(component.streamUrl()).toBeNull();
     expect(videos.streamUrl).not.toHaveBeenCalled();
   });
 
   it('enters the failed state when the recording cannot be loaded', () => {
-    const { component } = createFixture({ getVideo: vi.fn(() => throwError(() => new Error('boom'))) });
+    const { component } = createFixture({
+      getVideo: vi.fn(() => throwError(() => new Error('boom'))),
+    });
     expect(component.failed()).toBe(true);
     expect(component.loading()).toBe(false);
   });
@@ -166,12 +177,18 @@ describe('VideoPlayer', () => {
 
   describe('sidebar tabs', () => {
     it('defaults to the recordings tab when siblings are loaded', () => {
-      const { component } = createFixture({ groupId: 'g1', getVideosForGroup: vi.fn(() => of({ videos: [{ videoId: 'a' }] })) });
+      const { component } = createFixture({
+        groupId: 'g1',
+        getVideosForGroup: vi.fn(() => of({ videos: [{ videoId: 'a' }] })),
+      });
       expect(component.activeTab()).toBe('recordings');
     });
 
     it('switches to the comments tab when requested', () => {
-      const { component } = createFixture({ groupId: 'g1', getVideosForGroup: vi.fn(() => of({ videos: [{ videoId: 'a' }] })) });
+      const { component } = createFixture({
+        groupId: 'g1',
+        getVideosForGroup: vi.fn(() => of({ videos: [{ videoId: 'a' }] })),
+      });
       component.setTab('comments');
       expect(component.activeTab()).toBe('comments');
     });

--- a/src/my-dance.web/src/app/features/videos/video-player.ts
+++ b/src/my-dance.web/src/app/features/videos/video-player.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
+  computed,
   effect,
   inject,
   input,
@@ -19,6 +20,8 @@ import { CommentResponse, VideoInformation } from '../../core/api/api-models';
 import { CommentEdit, CommentReport, CommentsSection } from '../comments/comments-section';
 import { LongDatePipe } from '../../shared/format/long-date.pipe';
 import { VideoList } from '../../shared/ui/video-list/video-list';
+
+export type SidebarTab = 'comments' | 'recordings';
 
 @Component({
   selector: 'app-video-player',
@@ -53,6 +56,16 @@ export class VideoPlayer {
   readonly editingName = signal(false);
   readonly nameDraft = signal('');
   readonly renaming = signal(false);
+
+  /** User-selected tab. Reads through `activeTab` to guard against stale `recordings` state when no siblings are loaded. */
+  private readonly tabChoice = signal<SidebarTab>('recordings');
+  readonly activeTab = computed<SidebarTab>(() =>
+    this.tabChoice() === 'recordings' && this.siblings().length === 0 ? 'comments' : this.tabChoice(),
+  );
+
+  setTab(tab: SidebarTab): void {
+    this.tabChoice.set(tab);
+  }
 
   constructor() {
     // Reload when the recording changes (incl. navigating between siblings,

--- a/src/my-dance.web/src/app/shared/ui/video-card/video-card.spec.ts
+++ b/src/my-dance.web/src/app/shared/ui/video-card/video-card.spec.ts
@@ -15,13 +15,13 @@ const CONVERTED: VideoInformation = {
 
 async function setup(
   video: VideoInformation,
-  inputs: Partial<{ shareable: boolean; selected: boolean; queryParams: Record<string, string>; badge: string }> = {},
+  inputs: Partial<{
+    shareable: boolean;
+    selected: boolean;
+    queryParams: Record<string, string>;
+    badge: string;
+  }> = {},
 ): Promise<ComponentFixture<VideoCard>> {
-  await TestBed.configureTestingModule({
-    imports: [VideoCard],
-    providers: [provideRouter([])],
-  }).compileComponents();
-
   const fixture = TestBed.createComponent(VideoCard);
   fixture.componentRef.setInput('video', video);
   for (const [key, value] of Object.entries(inputs)) {
@@ -32,16 +32,41 @@ async function setup(
 }
 
 describe('VideoCard', () => {
-  it('renders the name, formatted recorded date, and duration', async () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [VideoCard],
+      providers: [provideRouter([])],
+    }).compileComponents();
+  });
+
+  it('renders the name, formatted recorded date, and duration badge', async () => {
     const el = (await setup(CONVERTED)).nativeElement as HTMLElement;
     expect(el.querySelector('h3')?.textContent).toContain('Waltz basics');
     const meta = el.querySelector('p')?.textContent ?? '';
     expect(meta).toContain('04 June 2026');
-    expect(meta).toContain('3:21');
+    expect(meta).not.toContain('3:21');
+    expect(el.querySelector('.video-card__duration')?.textContent?.trim()).toBe('3:21');
+  });
+
+  it('formats duration once in the preview badge', async () => {
+    const el = (await setup({ ...CONVERTED, duration: '00:03:21.0000000' }))
+      .nativeElement as HTMLElement;
+
+    expect(el.querySelector('.video-card__duration')?.textContent?.trim()).toBe('3:21');
+    expect(el.textContent?.match(/3:21/g)).toHaveLength(1);
+  });
+
+  it('formats ISO and seconds durations', async () => {
+    const iso = (await setup({ ...CONVERTED, duration: 'PT1H2M3S' })).nativeElement as HTMLElement;
+    expect(iso.querySelector('.video-card__duration')?.textContent?.trim()).toBe('1:02:03');
+
+    const seconds = (await setup({ ...CONVERTED, duration: '61' })).nativeElement as HTMLElement;
+    expect(seconds.querySelector('.video-card__duration')?.textContent?.trim()).toBe('1:01');
   });
 
   it('links Watch to the player using the blob id and query params', async () => {
-    const el = (await setup(CONVERTED, { queryParams: { groupId: 'g1' } })).nativeElement as HTMLElement;
+    const el = (await setup(CONVERTED, { queryParams: { groupId: 'g1' } }))
+      .nativeElement as HTMLElement;
     const watch = el.querySelector('a.button.is-primary');
     expect(watch?.textContent).toContain('Watch');
     expect(watch?.getAttribute('href')).toBe('/videos/blob1?groupId=g1');

--- a/src/my-dance.web/src/app/shared/ui/video-card/video-card.spec.ts
+++ b/src/my-dance.web/src/app/shared/ui/video-card/video-card.spec.ts
@@ -102,10 +102,26 @@ describe('VideoCard', () => {
 
   it('renders the badge when provided and omits it when empty', async () => {
     const withBadge = (await setup(CONVERTED, { badge: 'Salsa' })).nativeElement as HTMLElement;
-    const tag = withBadge.querySelector('.tag.is-info');
+    const tag = withBadge.querySelector('.video-card__badge');
     expect(tag?.textContent?.trim()).toBe('Salsa');
 
     const withoutBadge = (await setup(CONVERTED)).nativeElement as HTMLElement;
-    expect(withoutBadge.querySelector('.tag.is-info')).toBeNull();
+    expect(withoutBadge.querySelector('.video-card__badge')).toBeNull();
+  });
+
+  it('assigns badge colors deterministically from the badge text', async () => {
+    const first = (await setup(CONVERTED, { badge: 'Salsa' })).nativeElement as HTMLElement;
+    const second = (await setup(CONVERTED, { badge: 'Salsa' })).nativeElement as HTMLElement;
+    const different = (await setup(CONVERTED, { badge: 'Tango' })).nativeElement as HTMLElement;
+
+    const firstBadge = first.querySelector('.video-card__badge') as HTMLElement;
+    const secondBadge = second.querySelector('.video-card__badge') as HTMLElement;
+    const differentBadge = different.querySelector('.video-card__badge') as HTMLElement;
+
+    expect(firstBadge.dataset['badgeTone']).toBe(secondBadge.dataset['badgeTone']);
+    expect(firstBadge.style.getPropertyValue('--video-card-badge-bg')).toBe(
+      secondBadge.style.getPropertyValue('--video-card-badge-bg'),
+    );
+    expect(firstBadge.dataset['badgeTone']).not.toBe(differentBadge.dataset['badgeTone']);
   });
 });

--- a/src/my-dance.web/src/app/shared/ui/video-card/video-card.spec.ts
+++ b/src/my-dance.web/src/app/shared/ui/video-card/video-card.spec.ts
@@ -15,7 +15,7 @@ const CONVERTED: VideoInformation = {
 
 async function setup(
   video: VideoInformation,
-  inputs: Partial<{ shareable: boolean; selected: boolean; queryParams: Record<string, string> }> = {},
+  inputs: Partial<{ shareable: boolean; selected: boolean; queryParams: Record<string, string>; badge: string }> = {},
 ): Promise<ComponentFixture<VideoCard>> {
   await TestBed.configureTestingModule({
     imports: [VideoCard],
@@ -73,5 +73,14 @@ describe('VideoCard', () => {
   it('highlights the card when selected', async () => {
     const el = (await setup(CONVERTED, { selected: true })).nativeElement as HTMLElement;
     expect(el.querySelector('.card')?.classList).toContain('has-background-link-light');
+  });
+
+  it('renders the badge when provided and omits it when empty', async () => {
+    const withBadge = (await setup(CONVERTED, { badge: 'Salsa' })).nativeElement as HTMLElement;
+    const tag = withBadge.querySelector('.tag.is-info');
+    expect(tag?.textContent?.trim()).toBe('Salsa');
+
+    const withoutBadge = (await setup(CONVERTED)).nativeElement as HTMLElement;
+    expect(withoutBadge.querySelector('.tag.is-info')).toBeNull();
   });
 });

--- a/src/my-dance.web/src/app/shared/ui/video-card/video-card.ts
+++ b/src/my-dance.web/src/app/shared/ui/video-card/video-card.ts
@@ -26,7 +26,15 @@ import { LongDatePipe } from '../../format/long-date.pipe';
         <div class="video-card__header">
           <div>
             @if (badge()) {
-              <span class="tag is-info is-light video-card__badge">{{ badge() }}</span>
+              <span
+                class="tag video-card__badge"
+                [attr.data-badge-tone]="badgeTone().index"
+                [style.--video-card-badge-bg]="badgeTone().background"
+                [style.--video-card-badge-border]="badgeTone().border"
+                [style.--video-card-badge-text]="badgeTone().text"
+              >
+                {{ badge() }}
+              </span>
             }
             <h3 class="title is-6 video-card__title">{{ video().name || 'Untitled recording' }}</h3>
           </div>
@@ -171,6 +179,10 @@ import { LongDatePipe } from '../../format/long-date.pipe';
     .video-card__badge {
       max-width: 100%;
       margin-bottom: 0.45rem;
+      border: 1px solid var(--video-card-badge-border);
+      background: var(--video-card-badge-bg);
+      color: var(--video-card-badge-text);
+      font-weight: 700;
     }
 
     .video-card__title {
@@ -244,6 +256,37 @@ export class VideoCard {
   readonly share = output<VideoInformation>();
 
   readonly formattedDuration = computed(() => formatDuration(this.video().duration));
+  readonly badgeTone = computed(() => getBadgeTone(this.badge()));
+}
+
+interface BadgeTone {
+  readonly index: number;
+  readonly background: string;
+  readonly border: string;
+  readonly text: string;
+}
+
+const BADGE_TONES: readonly Omit<BadgeTone, 'index'>[] = [
+  { background: '#e8f3ff', border: '#a9d2ff', text: '#15518a' },
+  { background: '#eaf7ef', border: '#acdcbc', text: '#1f6b3b' },
+  { background: '#fff1d7', border: '#f2c16b', text: '#7a4a08' },
+  { background: '#f0edff', border: '#c7bbff', text: '#4a3a96' },
+  { background: '#ffecef', border: '#f4adbb', text: '#8a2d42' },
+  { background: '#e7f7f7', border: '#9fd7d6', text: '#176365' },
+];
+
+function getBadgeTone(text: string): BadgeTone {
+  const index = hashText(text.trim().toLowerCase()) % BADGE_TONES.length;
+  return { index, ...BADGE_TONES[index] };
+}
+
+function hashText(text: string): number {
+  let hash = 0;
+  for (let i = 0; i < text.length; i++) {
+    hash = (hash * 31 + text.charCodeAt(i)) >>> 0;
+  }
+
+  return hash;
 }
 
 function formatDuration(duration: string | undefined): string {

--- a/src/my-dance.web/src/app/shared/ui/video-card/video-card.ts
+++ b/src/my-dance.web/src/app/shared/ui/video-card/video-card.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
 import { Params, RouterLink } from '@angular/router';
 
 import { VideoInformation } from '../../../core/api/api-models';
@@ -10,33 +10,225 @@ import { LongDatePipe } from '../../format/long-date.pipe';
   imports: [RouterLink, LongDatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="card" [class.has-background-link-light]="selected()">
-      <div class="card-content">
-        @if (badge()) {
-          <span class="tag is-info is-light mb-2">{{ badge() }}</span>
+    <article
+      class="card video-card"
+      [class.has-background-link-light]="selected()"
+      [class.is-selected]="selected()"
+    >
+      <div class="video-card__preview" aria-hidden="true">
+        <span class="video-card__play"></span>
+        @if (formattedDuration()) {
+          <span class="video-card__duration">{{ formattedDuration() }}</span>
         }
-        <h3 class="title is-6 mb-1">{{ video().name }}</h3>
-        <p class="is-size-7 has-text-grey">
-          {{ video().recordedDateTime | longDate }}
-          @if (video().duration) {
-            · {{ video().duration }}
+      </div>
+
+      <div class="card-content">
+        <div class="video-card__header">
+          <div>
+            @if (badge()) {
+              <span class="tag is-info is-light video-card__badge">{{ badge() }}</span>
+            }
+            <h3 class="title is-6 video-card__title">{{ video().name || 'Untitled recording' }}</h3>
+          </div>
+
+          @if (!video().converted || !video().blobId) {
+            <span class="tag is-warning is-light video-card__status">Processing&hellip;</span>
           }
+        </div>
+
+        <p class="is-size-7 has-text-grey video-card__meta">
+          <span class="video-card__meta-icon" aria-hidden="true"></span>
+          <span>{{ video().recordedDateTime | longDate }}</span>
         </p>
 
-        <div class="buttons are-small mt-3">
+        <div class="buttons are-small video-card__actions">
           @if (video().converted && video().blobId) {
-            <a class="button is-primary" [routerLink]="['/videos', video().blobId]" [queryParams]="queryParams()">
+            <a
+              class="button is-primary video-card__watch"
+              [routerLink]="['/videos', video().blobId]"
+              [queryParams]="queryParams()"
+            >
+              <span class="video-card__button-icon" aria-hidden="true"></span>
               Watch
             </a>
-          } @else {
-            <span class="tag is-warning is-light">Processing…</span>
           }
           @if (shareable()) {
-            <button type="button" class="button is-light" (click)="share.emit(video())">Share</button>
+            <button
+              type="button"
+              class="button is-light video-card__share"
+              (click)="share.emit(video())"
+            >
+              Share
+            </button>
           }
         </div>
       </div>
-    </div>
+    </article>
+  `,
+  styles: `
+    :host {
+      display: block;
+      height: 100%;
+    }
+
+    .video-card {
+      height: 100%;
+      overflow: hidden;
+      border: 1px solid color-mix(in srgb, var(--bulma-border) 80%, transparent);
+      border-radius: 8px;
+      box-shadow: 0 0.4rem 1rem rgba(20, 26, 44, 0.08);
+      transition:
+        transform 140ms ease,
+        box-shadow 140ms ease,
+        border-color 140ms ease;
+    }
+
+    .video-card:hover,
+    .video-card:focus-within {
+      transform: translateY(-2px);
+      border-color: color-mix(in srgb, var(--bulma-primary) 42%, var(--bulma-border));
+      box-shadow: 0 0.8rem 1.6rem rgba(20, 26, 44, 0.13);
+    }
+
+    .video-card.is-selected {
+      border-color: var(--bulma-link);
+      box-shadow:
+        0 0 0 1px var(--bulma-link),
+        0 0.8rem 1.6rem rgba(72, 95, 199, 0.18);
+    }
+
+    .video-card__preview {
+      position: relative;
+      display: grid;
+      min-height: 7rem;
+      place-items: center;
+      background:
+        radial-gradient(circle at 82% 18%, rgba(255, 255, 255, 0.34), transparent 24%),
+        linear-gradient(135deg, #20314f 0%, #2f6f73 56%, #f0b35a 100%);
+    }
+
+    .video-card__preview::after {
+      position: absolute;
+      inset: auto 0 0;
+      height: 42%;
+      content: '';
+      background: linear-gradient(to top, rgba(0, 0, 0, 0.22), transparent);
+    }
+
+    .video-card__play {
+      z-index: 1;
+      display: grid;
+      width: 3rem;
+      height: 3rem;
+      place-items: center;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.92);
+      box-shadow: 0 0.45rem 1.2rem rgba(0, 0, 0, 0.22);
+    }
+
+    .video-card__play::before,
+    .video-card__button-icon::before {
+      display: block;
+      width: 0;
+      height: 0;
+      margin-left: 0.15rem;
+      border-top: 0.45rem solid transparent;
+      border-bottom: 0.45rem solid transparent;
+      border-left: 0.7rem solid currentColor;
+      color: var(--bulma-primary);
+      content: '';
+    }
+
+    .video-card__duration {
+      position: absolute;
+      right: 0.75rem;
+      bottom: 0.65rem;
+      z-index: 1;
+      padding: 0.2rem 0.45rem;
+      border-radius: 0.35rem;
+      background: rgba(0, 0, 0, 0.68);
+      color: #fff;
+      font-size: 0.75rem;
+      font-weight: 700;
+      line-height: 1;
+    }
+
+    .card-content {
+      display: flex;
+      min-height: 11rem;
+      flex-direction: column;
+      gap: 0.75rem;
+      padding: 1rem;
+    }
+
+    .video-card__header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 0.75rem;
+    }
+
+    .video-card__badge {
+      max-width: 100%;
+      margin-bottom: 0.45rem;
+    }
+
+    .video-card__title {
+      display: -webkit-box;
+      margin-bottom: 0;
+      overflow: hidden;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2;
+      line-height: 1.25;
+    }
+
+    .video-card__status {
+      flex: 0 0 auto;
+    }
+
+    .video-card__meta {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 0.35rem;
+      margin: 0;
+    }
+
+    .video-card__meta-icon {
+      width: 0.8rem;
+      height: 0.8rem;
+      border: 2px solid currentColor;
+      border-radius: 999px;
+      opacity: 0.7;
+    }
+
+    .video-card__actions {
+      margin-top: auto;
+      margin-bottom: 0;
+      padding-top: 0.25rem;
+    }
+
+    .video-card__watch {
+      min-width: 6rem;
+      font-weight: 700;
+    }
+
+    .video-card__button-icon {
+      display: inline-grid;
+      width: 1rem;
+      place-items: center;
+    }
+
+    .video-card__button-icon::before {
+      border-top-width: 0.3rem;
+      border-bottom-width: 0.3rem;
+      border-left-width: 0.48rem;
+      color: currentColor;
+    }
+
+    .video-card__share {
+      font-weight: 600;
+    }
   `,
 })
 export class VideoCard {
@@ -50,4 +242,65 @@ export class VideoCard {
   /** Optional contextual label shown above the title (e.g. group name). */
   readonly badge = input('');
   readonly share = output<VideoInformation>();
+
+  readonly formattedDuration = computed(() => formatDuration(this.video().duration));
+}
+
+function formatDuration(duration: string | undefined): string {
+  const trimmed = duration?.trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  const seconds = parseDurationSeconds(trimmed);
+  if (seconds === null) {
+    return trimmed;
+  }
+
+  return formatSeconds(seconds);
+}
+
+function parseDurationSeconds(duration: string): number | null {
+  const iso = duration.match(
+    /^P(?:\d+D)?T(?:(\d+(?:\.\d+)?)H)?(?:(\d+(?:\.\d+)?)M)?(?:(\d+(?:\.\d+)?)S)?$/i,
+  );
+  if (iso) {
+    const [, hours = '0', minutes = '0', seconds = '0'] = iso;
+    return Math.round(Number(hours) * 3600 + Number(minutes) * 60 + Number(seconds));
+  }
+
+  if (/^\d+(?:\.\d+)?$/.test(duration)) {
+    return Math.round(Number(duration));
+  }
+
+  const timeSpan = duration.match(/^(?:(\d+)\.)?(\d+):(\d{1,2})(?::(\d{1,2}(?:\.\d+)?))?$/);
+  if (timeSpan) {
+    const [, days = '0', first, second, third] = timeSpan;
+    const hours = third === undefined ? '0' : first;
+    const minutes = third === undefined ? first : second;
+    const seconds = third === undefined ? second : third;
+
+    return Math.round(
+      Number(days) * 86400 + Number(hours) * 3600 + Number(minutes) * 60 + Number(seconds),
+    );
+  }
+
+  return null;
+}
+
+function formatSeconds(totalSeconds: number): string {
+  const clampedSeconds = Math.max(0, totalSeconds);
+  const hours = Math.floor(clampedSeconds / 3600);
+  const minutes = Math.floor((clampedSeconds % 3600) / 60);
+  const seconds = clampedSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}:${padTimePart(minutes)}:${padTimePart(seconds)}`;
+  }
+
+  return `${minutes}:${padTimePart(seconds)}`;
+}
+
+function padTimePart(value: number): string {
+  return value.toString().padStart(2, '0');
 }

--- a/src/my-dance.web/src/app/shared/ui/video-card/video-card.ts
+++ b/src/my-dance.web/src/app/shared/ui/video-card/video-card.ts
@@ -12,6 +12,9 @@ import { LongDatePipe } from '../../format/long-date.pipe';
   template: `
     <div class="card" [class.has-background-link-light]="selected()">
       <div class="card-content">
+        @if (badge()) {
+          <span class="tag is-info is-light mb-2">{{ badge() }}</span>
+        }
         <h3 class="title is-6 mb-1">{{ video().name }}</h3>
         <p class="is-size-7 has-text-grey">
           {{ video().recordedDateTime | longDate }}
@@ -44,5 +47,7 @@ export class VideoCard {
   readonly queryParams = input<Params>({});
   /** Highlight this card as the currently-playing recording. */
   readonly selected = input(false);
+  /** Optional contextual label shown above the title (e.g. group name). */
+  readonly badge = input('');
   readonly share = output<VideoInformation>();
 }

--- a/src/my-dance.web/src/index.html
+++ b/src/my-dance.web/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
   <meta charset="utf-8">
   <title>Dance Dance</title>

--- a/src/my-dance.web/src/styles.scss
+++ b/src/my-dance.web/src/styles.scss
@@ -6,8 +6,3 @@ body {
   min-height: 100vh;
 }
 
-:root {
-  --bulma-primary-h: 30deg;
-  --bulma-primary-l: 50%;
-}
-

--- a/src/tests/TB.DanceDance.Tests/Features/AccessManagement/AccessManagementServiceTests.cs
+++ b/src/tests/TB.DanceDance.Tests/Features/AccessManagement/AccessManagementServiceTests.cs
@@ -163,6 +163,37 @@ public class AccessManagementServiceTests : BaseTestClass
     }
 
     [Fact]
+    public async Task GetAccessRequestsToApproveAsync_DoesNotReturnGroupRequest_WhenNoGroupAdmin_ButReturnsItOnceAdminExists()
+    {
+        // Regression: a pending group request is invisible to everyone until a matching
+        // GroupsAdmins row exists. The seed previously never created group admins, so group
+        // access requests never appeared on the "Requested accesses" page.
+        var approver = new UserDataBuilder().Build();
+        var requestor = new UserDataBuilder().Build();
+        var group = new GroupDataBuilder().Build();
+
+        SeedDbContext.AddRange(approver, requestor, group);
+        await SeedDbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        SeedDbContext.GroupAssigmentRequests.Add(new GroupAssigmentRequest
+        {
+            Id = Guid.NewGuid(), GroupId = group.Id, UserId = requestor.Id, Approved = null, WhenJoined = DateTime.UtcNow.AddDays(-1)
+        });
+        await SeedDbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // No GroupAdmin yet -> request must not be approvable by anyone.
+        var withoutAdmin = await service.GetAccessRequestsToApproveAsync(approver.Id, TestContext.Current.CancellationToken);
+        Assert.DoesNotContain(withoutAdmin, r => r.IsGroup && r.Name == group.Name);
+
+        // Grant group-admin rights -> request now appears.
+        SeedDbContext.GroupsAdmins.Add(new GroupAdmin { Id = Guid.NewGuid(), UserId = approver.Id, GroupId = group.Id });
+        await SeedDbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var withAdmin = await service.GetAccessRequestsToApproveAsync(approver.Id, TestContext.Current.CancellationToken);
+        Assert.Contains(withAdmin, r => r.IsGroup && r.Name == group.Name);
+    }
+
+    [Fact]
     public async Task ApproveAccessRequest_Group_CreatesMembershipAndMarksApproved()
     {
         var approver = new UserDataBuilder().Build();

--- a/tools/localsetup/dance-data-seed.sql
+++ b/tools/localsetup/dance-data-seed.sql
@@ -48,3 +48,22 @@ DO $$
 
     END $$;
 
+-- Second dev user (testemail2@email.com): limited access on purpose. Member of a single
+-- group ("Środy 18:00") and no events, so this user only sees the videos shared to that
+-- group (43e4d723..., c4029eb1...). Useful for testing per-user visibility/access boundaries.
+DO $$
+    DECLARE
+        userId text = '9f1c8e2a-4b6d-4c3e-8a7f-2d5e6b1a0c34';
+    BEGIN
+        IF NOT EXISTS (SELECT 1 from access."Users" where "Id" = userId)
+        THEN
+        RAISE NOTICE 'Second dance user NOT found. Inserting dance data.';
+        INSERT INTO access."Users" ("Id", "FirstName", "LastName", "Email") VALUES (userId, 'Tom2', 'B', 'testemail2@email.com');
+
+        INSERT INTO access."AssingedToGroups" ("Id", "GroupId", "UserId", "WhenJoined") VALUES (gen_random_uuid(), '7c30e3cc-e6d8-4cf7-8b64-eba68efa5366', userId, '2022-02-01 19:28:47.258000 +00:00');
+        ELSE
+            RAISE NOTICE 'Second dance user found. Skipping insert.';
+        end if;
+
+    END $$;
+

--- a/tools/localsetup/dance-data-seed.sql
+++ b/tools/localsetup/dance-data-seed.sql
@@ -42,6 +42,11 @@ DO $$
 
             INSERT INTO access."AssingedToGroups" ("Id", "GroupId", "UserId", "WhenJoined") VALUES (gen_random_uuid(), '2a7554e4-0dc3-4f92-be4c-e4463adf1cee', userId, '2022-02-01 19:28:47.258000 +00:00');
             INSERT INTO access."AssingedToGroups" ("Id", "GroupId", "UserId", "WhenJoined") VALUES (gen_random_uuid(), '7c30e3cc-e6d8-4cf7-8b64-eba68efa5366', userId, '2022-02-01 19:28:47.258000 +00:00');
+
+            -- Make Tom B an admin of both groups so group access requests are visible/approvable
+            -- (events are approvable via Events.Owner; groups need a GroupsAdmins row).
+            INSERT INTO access."GroupsAdmins" ("Id", "GroupId", "UserId") VALUES (gen_random_uuid(), '2a7554e4-0dc3-4f92-be4c-e4463adf1cee', userId);
+            INSERT INTO access."GroupsAdmins" ("Id", "GroupId", "UserId") VALUES (gen_random_uuid(), '7c30e3cc-e6d8-4cf7-8b64-eba68efa5366', userId);
         ELSE
             RAISE NOTICE 'Dance user found. Skipping insert.';
         end if;

--- a/tools/localsetup/identity-data-seed.sql
+++ b/tools/localsetup/identity-data-seed.sql
@@ -32,3 +32,40 @@ BEGIN
     END IF;
 END
 $$;
+
+-- Second dev user: testemail2@email.com / 1234 (same salted ASP.NET Identity hash as user 1;
+-- the v3 hash is not bound to the username, so it stays valid for password "1234").
+DO
+$$
+DECLARE
+    userId text = '9f1c8e2a-4b6d-4c3e-8a7f-2d5e6b1a0c34';
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM "Idp.Ident"."AspNetUsers" WHERE "Id" = userId) THEN
+        RAISE NOTICE 'Second test user not found. Inserting into Idp.Ident.AspNetUsers';
+
+        INSERT INTO "Idp.Ident"."AspNetUsers" ("Id", "UserName", "NormalizedUserName", "Email", "NormalizedEmail",
+                                               "EmailConfirmed", "PasswordHash", "SecurityStamp",
+                                               "ConcurrencyStamp",
+                                               "PhoneNumber", "PhoneNumberConfirmed", "TwoFactorEnabled",
+                                               "LockoutEnd",
+                                               "LockoutEnabled", "AccessFailedCount")
+        VALUES (userId, 'testemail2@email.com', 'TESTEMAIL2@EMAIL.COM', 'testemail2@email.com',
+                'TESTEMAIL2@EMAIL.COM', false,
+                'AQAAAAIAAYagAAAAELUtg1+KSabFIDi3guZ/hVZfnGtMvbJEM7zvQnfuxFGkNi06ZapZ1lHloP9hmRBUmg==',
+                '7QK3M5N2P8R4S6T9V1W3X5Y7Z2A4B6C8', 'a1b2c3d4-e5f6-47a8-9b0c-d1e2f3a4b5c6', null, false, false,
+                null,
+                true, 0);
+
+        INSERT INTO "Idp.Ident"."AspNetUserClaims" ("Id", "UserId", "ClaimType", "ClaimValue")
+        VALUES (DEFAULT, userId, 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', 'Tom Test2');
+        INSERT INTO "Idp.Ident"."AspNetUserClaims" ("Id", "UserId", "ClaimType", "ClaimValue")
+        VALUES (DEFAULT, userId, 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', 'testemail2@email.com');
+        INSERT INTO "Idp.Ident"."AspNetUserClaims" ("Id", "UserId", "ClaimType", "ClaimValue")
+        VALUES (DEFAULT, userId, 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname', 'Test');
+        INSERT INTO "Idp.Ident"."AspNetUserClaims" ("Id", "UserId", "ClaimType", "ClaimValue")
+        VALUES (DEFAULT, userId, 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname', 'Tom2');
+    ELSE
+        RAISE NOTICE 'Second test user found. Skipping insertion';
+    END IF;
+END
+$$;

--- a/tools/localsetup/oauth-data-seed.sql
+++ b/tools/localsetup/oauth-data-seed.sql
@@ -74,20 +74,22 @@ SET "ClientType" = EXCLUDED."ClientType",
     "PostLogoutRedirectUris" = EXCLUDED."PostLogoutRedirectUris",
     "Requirements" = EXCLUDED."Requirements";
 
--- Kept from legacy script mapping. This client requires enabling password flow in server configuration.
+-- Dev-only REST token client. Public (no secret) so any seeded user can fetch a token via
+-- the OAuth2 password grant with a single REST call. The password grant is only enabled on
+-- the auth server when AuthServer:AllowWeakPasswords=true (local development).
 INSERT INTO "Idp.Auth"."OpenIddictApplications" (
-    "Id", "ClientId", "ClientType", "DisplayName", "ClientSecret", "ConcurrencyToken",
+    "Id", "ClientId", "ClientType", "DisplayName", "ConcurrencyToken",
     "Permissions")
 VALUES (
     'app_tbdancedancehttpclient',
     'tbdancedancehttpclient',
-    'confidential',
+    'public',
     'TB DanceDance Http Client',
-    '4Vw/t6S10MOhxfx2mqQ995AVeyiUnyU1hWmX8Gn0Xxw=',
     md5(random()::text || clock_timestamp()::text),
     '["ept:token","gt:password","scp:openid","scp:profile","scp:tbdancedanceapi.read"]'
 )
 ON CONFLICT ("ClientId") DO UPDATE
 SET "ClientType" = EXCLUDED."ClientType",
     "DisplayName" = EXCLUDED."DisplayName",
+    "ClientSecret" = NULL,
     "Permissions" = EXCLUDED."Permissions";


### PR DESCRIPTION
## Summary

- **Upload pipeline**: Block-based large-file upload support with progress tracking per file; batch uploads now correctly continue when a single file fails (isolated `catchError` per item)
- **Events page**: Season-grouped event listing with create-event flow, per-event video list, and upload dialog pre-seeded to the selected event; undated events are no longer bucketed under a spurious '1970 Winter' group
- **Group videos**: Upload dialog embedded on the group recordings page
- **UI polish**: Orange primary color, improved video cards with badges, better recent-activity and dashboard layout, sharing dialog, sibling playlist navigation, download disabled
- **Access & sharing**: Request-access flow, manage-access-requests, shared-link viewer
- **Auth / seed**: Second dev user, dev-only password grant for easy local token retrieval, group admins in seed data
- **CI**: Frontend Vitest suite added to the PR gate; comprehensive test coverage across services, components, guards, pipes, and feature flows
- **Tooling**: `local-stack` Claude skill for Docker Compose run/debug/reset operations
