### PR TITLE
Add video thumbnail support to mobile app (DD-45)

### DIFF
--- a/src/mobile/TB.DanceDance.Mobile.Library/Data/Models/Video.cs
+++ b/src/mobile/TB.DanceDance.Mobile.Library/Data/Models/Video.cs
@@ -18,6 +18,7 @@ public record Video
     public Guid GroupId { get; set; }
     public UploadState? UploadState { get; set; }
     public bool Converted { get; set; } = false;
+    public string? ThumbnailUrl { get; set; }
 
 
     public static List<Video> MapFromApiResponse(IReadOnlyCollection<VideoFromGroupInformation>? videosResponse)
@@ -34,6 +35,7 @@ public record Video
             GroupId = v.GroupId,
             BlobId = v.BlobId,
             Converted = v.Converted,
+            ThumbnailUrl = v.ThumbnailUrl,
         }).ToList();
     }
 
@@ -46,6 +48,7 @@ public record Video
             When = r.RecordedDateTime,
             BlobId = r.BlobId,
             Converted = r.Converted,
+            ThumbnailUrl = r.ThumbnailUrl,
         }).ToList();
     }
 }

--- a/src/mobile/TB.DanceDance.Mobile.Library/Services/Network/NetworkAddressResolver.cs
+++ b/src/mobile/TB.DanceDance.Mobile.Library/Services/Network/NetworkAddressResolver.cs
@@ -15,10 +15,11 @@ public class NetworkAddressResolver
 
     private const string Localhost = "localhost";
     private const string LoopAddress = "127.0.0.1";
+    private const string DockerHostAlias = "host.docker.internal";
     private const string AndroidHostMachine = "10.0.2.2";
-    
+
 #endif
-    
+
     public Uri Resolve(Uri uri)
     {
         #if DEBUG
@@ -29,13 +30,15 @@ public class NetworkAddressResolver
                 return new UriBuilder(uri) { Host = AndroidHostMachine }.Uri;
             if (uri.Host.Equals(LoopAddress))
                 return new UriBuilder(uri) { Host = AndroidHostMachine }.Uri;
+            if (uri.Host.Equals(DockerHostAlias))
+                return new UriBuilder(uri) { Host = AndroidHostMachine }.Uri;
         }
-            
+
         #endif
-        
+
         return uri;
     }
-    
+
     public string Resolve(string uri)
     {
 #if DEBUG
@@ -43,10 +46,11 @@ public class NetworkAddressResolver
         if (platform == DevicePlatform.Android)
         {
             return uri.Replace(Localhost, AndroidHostMachine)
-                .Replace(LoopAddress, AndroidHostMachine);
+                .Replace(LoopAddress, AndroidHostMachine)
+                .Replace(DockerHostAlias, AndroidHostMachine);
         }
 #endif
-        
+
         return uri;
     }
     

--- a/src/mobile/TB.DanceDance.Mobile/Pages/Controls/VideoThumbnail.xaml
+++ b/src/mobile/TB.DanceDance.Mobile/Pages/Controls/VideoThumbnail.xaml
@@ -10,43 +10,36 @@
         </ResourceDictionary>
     </ContentView.Resources>
 
-    <Border StrokeShape="RoundRectangle 8"
-            Stroke="Transparent"
-            Padding="0"
-            HeightRequest="72"
-            WidthRequest="110"
-            HorizontalOptions="Start">
-        <Grid>
-            <Image Source="{Binding ThumbnailUrl, Source={x:Reference VideoThumbnailRoot}}"
-                   Aspect="AspectFill"
-                   IsVisible="{Binding HasThumbnail, Source={x:Reference VideoThumbnailRoot}}" />
+    <Grid HeightRequest="160" HorizontalOptions="Fill">
+        <Image Source="{Binding ThumbnailUrl, Source={x:Reference VideoThumbnailRoot}}"
+               Aspect="AspectFill"
+               IsVisible="{Binding HasThumbnail, Source={x:Reference VideoThumbnailRoot}}" />
 
-            <Grid IsVisible="{Binding HasThumbnail, Source={x:Reference VideoThumbnailRoot}, Converter={StaticResource InverseBooleanConverter}}">
-                <BoxView>
-                    <BoxView.Background>
-                        <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
-                            <GradientStop Color="#20314f" Offset="0.0" />
-                            <GradientStop Color="#2f6f73" Offset="0.56" />
-                            <GradientStop Color="#f0b35a" Offset="1.0" />
-                        </LinearGradientBrush>
-                    </BoxView.Background>
-                </BoxView>
+        <Grid IsVisible="{Binding HasThumbnail, Source={x:Reference VideoThumbnailRoot}, Converter={StaticResource InverseBooleanConverter}}">
+            <BoxView>
+                <BoxView.Background>
+                    <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+                        <GradientStop Color="#20314f" Offset="0.0" />
+                        <GradientStop Color="#2f6f73" Offset="0.56" />
+                        <GradientStop Color="#f0b35a" Offset="1.0" />
+                    </LinearGradientBrush>
+                </BoxView.Background>
+            </BoxView>
 
-                <Border StrokeShape="RoundRectangle 999"
-                        Stroke="Transparent"
-                        BackgroundColor="#EBFFFFFF"
-                        Padding="0"
-                        HeightRequest="28"
-                        WidthRequest="28"
-                        HorizontalOptions="Center"
-                        VerticalOptions="Center">
-                    <Polygon Points="0,0 0,14 12,7"
-                             Fill="{StaticResource Primary}"
-                             HorizontalOptions="Center"
-                             VerticalOptions="Center"
-                             Margin="10,7,0,0" />
-                </Border>
-            </Grid>
+            <Border StrokeShape="RoundRectangle 999"
+                    Stroke="Transparent"
+                    BackgroundColor="#EBFFFFFF"
+                    Padding="0"
+                    HeightRequest="48"
+                    WidthRequest="48"
+                    HorizontalOptions="Center"
+                    VerticalOptions="Center">
+                <Polygon Points="0,0 0,22 19,11"
+                         Fill="{StaticResource Primary}"
+                         HorizontalOptions="Center"
+                         VerticalOptions="Center"
+                         Margin="16,11,0,0" />
+            </Border>
         </Grid>
-    </Border>
+    </Grid>
 </ContentView>

--- a/src/mobile/TB.DanceDance.Mobile/Pages/Controls/VideoThumbnail.xaml
+++ b/src/mobile/TB.DanceDance.Mobile/Pages/Controls/VideoThumbnail.xaml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:converters="clr-namespace:TB.DanceDance.Mobile.Converters"
+             x:Class="TB.DanceDance.Mobile.Pages.Controls.VideoThumbnail"
+             x:Name="VideoThumbnailRoot">
+    <ContentView.Resources>
+        <ResourceDictionary>
+            <converters:NegativeBoolConverter x:Key="InverseBooleanConverter" />
+        </ResourceDictionary>
+    </ContentView.Resources>
+
+    <Border StrokeShape="RoundRectangle 8"
+            Stroke="Transparent"
+            Padding="0"
+            HeightRequest="72"
+            WidthRequest="110"
+            HorizontalOptions="Start">
+        <Grid>
+            <Image Source="{Binding ThumbnailUrl, Source={x:Reference VideoThumbnailRoot}}"
+                   Aspect="AspectFill"
+                   IsVisible="{Binding HasThumbnail, Source={x:Reference VideoThumbnailRoot}}" />
+
+            <Grid IsVisible="{Binding HasThumbnail, Source={x:Reference VideoThumbnailRoot}, Converter={StaticResource InverseBooleanConverter}}">
+                <BoxView>
+                    <BoxView.Background>
+                        <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+                            <GradientStop Color="#20314f" Offset="0.0" />
+                            <GradientStop Color="#2f6f73" Offset="0.56" />
+                            <GradientStop Color="#f0b35a" Offset="1.0" />
+                        </LinearGradientBrush>
+                    </BoxView.Background>
+                </BoxView>
+
+                <Border StrokeShape="RoundRectangle 999"
+                        Stroke="Transparent"
+                        BackgroundColor="#EBFFFFFF"
+                        Padding="0"
+                        HeightRequest="28"
+                        WidthRequest="28"
+                        HorizontalOptions="Center"
+                        VerticalOptions="Center">
+                    <Polygon Points="0,0 0,14 12,7"
+                             Fill="{StaticResource Primary}"
+                             HorizontalOptions="Center"
+                             VerticalOptions="Center"
+                             Margin="10,7,0,0" />
+                </Border>
+            </Grid>
+        </Grid>
+    </Border>
+</ContentView>

--- a/src/mobile/TB.DanceDance.Mobile/Pages/Controls/VideoThumbnail.xaml
+++ b/src/mobile/TB.DanceDance.Mobile/Pages/Controls/VideoThumbnail.xaml
@@ -11,7 +11,7 @@
     </ContentView.Resources>
 
     <Grid HeightRequest="160" HorizontalOptions="Fill">
-        <Image Source="{Binding ThumbnailUrl, Source={x:Reference VideoThumbnailRoot}}"
+        <Image Source="{Binding ResolvedThumbnailUrl, Source={x:Reference VideoThumbnailRoot}}"
                Aspect="AspectFill"
                IsVisible="{Binding HasThumbnail, Source={x:Reference VideoThumbnailRoot}}" />
 

--- a/src/mobile/TB.DanceDance.Mobile/Pages/Controls/VideoThumbnail.xaml.cs
+++ b/src/mobile/TB.DanceDance.Mobile/Pages/Controls/VideoThumbnail.xaml.cs
@@ -1,0 +1,37 @@
+namespace TB.DanceDance.Mobile.Pages.Controls;
+
+public partial class VideoThumbnail
+{
+    public static readonly BindableProperty ThumbnailUrlProperty = BindableProperty.Create(
+        nameof(ThumbnailUrl),
+        typeof(string),
+        typeof(VideoThumbnail),
+        propertyChanged: OnThumbnailUrlChanged);
+
+    private static readonly BindablePropertyKey HasThumbnailPropertyKey = BindableProperty.CreateReadOnly(
+        nameof(HasThumbnail),
+        typeof(bool),
+        typeof(VideoThumbnail),
+        false);
+
+    public static readonly BindableProperty HasThumbnailProperty = HasThumbnailPropertyKey.BindableProperty;
+
+    public VideoThumbnail()
+    {
+        InitializeComponent();
+    }
+
+    public string? ThumbnailUrl
+    {
+        get => (string?)GetValue(ThumbnailUrlProperty);
+        set => SetValue(ThumbnailUrlProperty, value);
+    }
+
+    public bool HasThumbnail => (bool)GetValue(HasThumbnailProperty);
+
+    private static void OnThumbnailUrlChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        var control = (VideoThumbnail)bindable;
+        control.SetValue(HasThumbnailPropertyKey, !string.IsNullOrWhiteSpace(newValue as string));
+    }
+}

--- a/src/mobile/TB.DanceDance.Mobile/Pages/Controls/VideoThumbnail.xaml.cs
+++ b/src/mobile/TB.DanceDance.Mobile/Pages/Controls/VideoThumbnail.xaml.cs
@@ -1,3 +1,6 @@
+using Microsoft.Extensions.DependencyInjection;
+using TB.DanceDance.Mobile.Library.Services.Network;
+
 namespace TB.DanceDance.Mobile.Pages.Controls;
 
 public partial class VideoThumbnail
@@ -16,6 +19,17 @@ public partial class VideoThumbnail
 
     public static readonly BindableProperty HasThumbnailProperty = HasThumbnailPropertyKey.BindableProperty;
 
+    private static readonly BindablePropertyKey ResolvedThumbnailUrlPropertyKey = BindableProperty.CreateReadOnly(
+        nameof(ResolvedThumbnailUrl),
+        typeof(string),
+        typeof(VideoThumbnail),
+        null);
+
+    public static readonly BindableProperty ResolvedThumbnailUrlProperty = ResolvedThumbnailUrlPropertyKey.BindableProperty;
+
+    private readonly NetworkAddressResolver? networkAddressResolver =
+        IPlatformApplication.Current?.Services.GetService<NetworkAddressResolver>();
+
     public VideoThumbnail()
     {
         InitializeComponent();
@@ -29,9 +43,20 @@ public partial class VideoThumbnail
 
     public bool HasThumbnail => (bool)GetValue(HasThumbnailProperty);
 
+    /// <summary>
+    /// ThumbnailUrl rewritten for the running platform (e.g. host.docker.internal -> 10.0.2.2
+    /// on the Android emulator), since &lt;Image&gt;/UriImageSource loads bypass the app's
+    /// HttpClient pipeline and the DebuggingUrlHandler that normally handles this.
+    /// </summary>
+    public string? ResolvedThumbnailUrl => (string?)GetValue(ResolvedThumbnailUrlProperty);
+
     private static void OnThumbnailUrlChanged(BindableObject bindable, object oldValue, object newValue)
     {
         var control = (VideoThumbnail)bindable;
-        control.SetValue(HasThumbnailPropertyKey, !string.IsNullOrWhiteSpace(newValue as string));
+        var url = newValue as string;
+
+        control.SetValue(HasThumbnailPropertyKey, !string.IsNullOrWhiteSpace(url));
+        control.SetValue(ResolvedThumbnailUrlPropertyKey,
+            string.IsNullOrWhiteSpace(url) ? null : control.networkAddressResolver?.Resolve(url) ?? url);
     }
 }

--- a/src/mobile/TB.DanceDance.Mobile/Pages/EventDetailsPage.xaml
+++ b/src/mobile/TB.DanceDance.Mobile/Pages/EventDetailsPage.xaml
@@ -25,35 +25,40 @@
                             BindableLayout.ItemsSource="{Binding Videos}">
                             <BindableLayout.ItemTemplate>
                                 <DataTemplate x:DataType="models:Video">
-                                    <Border Padding="10" Margin="0,10,0,0" IsEnabled="{Binding Converted}">
-                                        <Grid>
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition></ColumnDefinition>
-                                                <ColumnDefinition></ColumnDefinition>
-                                            </Grid.ColumnDefinitions>
-                                            <VerticalStackLayout>
-                                                <Label Text="{Binding Name}" FontSize="24">
-                                                    <Label.GestureRecognizers>
-                                                        <TapGestureRecognizer
-                                                            Command="{Binding NavigateToWatchVideoCommand, Source={RelativeSource AncestorType={x:Type pageModels:EventDetailsPageModel}}, x:DataType=pageModels:EventDetailsPageModel}"
-                                                            CommandParameter="{Binding .}" />
-                                                    </Label.GestureRecognizers>
-                                                </Label>
-                                                <Label
-                                                    Text="{Binding When, Converter={StaticResource DateTimeConverter}}" />
-                                                <Label Text="Nagranie nie jest gotowe."
-                                                       IsVisible="{Binding Converted, Converter={StaticResource InverseBooleanConverter}}"
-                                                       TextColor="{StaticResource Magenta}">
-                                                </Label>
-                                            </VerticalStackLayout>
+                                    <Border Padding="0" Margin="0,10,0,0" StrokeShape="RoundRectangle 8" IsEnabled="{Binding Converted}">
+                                        <VerticalStackLayout Spacing="0">
+                                            <controls:VideoThumbnail
+                                                ThumbnailUrl="{Binding ThumbnailUrl}"
+                                                HorizontalOptions="Fill" />
 
-                                            <controls:EditButton Grid.Column="1"
-                                                                 Command="{Binding RenameVideoCommand, Source={RelativeSource AncestorType={x:Type pageModels:EventDetailsPageModel}}, x:DataType=pageModels:EventDetailsPageModel}"
-                                                                 CommandParameter="{Binding Id}"
-                                                                 HorizontalOptions="End"
-                                                                 VerticalOptions="Center" />
+                                            <Grid Padding="10">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition></ColumnDefinition>
+                                                    <ColumnDefinition Width="Auto"></ColumnDefinition>
+                                                </Grid.ColumnDefinitions>
+                                                <VerticalStackLayout Grid.Column="0">
+                                                    <Label Text="{Binding Name}" FontSize="24">
+                                                        <Label.GestureRecognizers>
+                                                            <TapGestureRecognizer
+                                                                Command="{Binding NavigateToWatchVideoCommand, Source={RelativeSource AncestorType={x:Type pageModels:EventDetailsPageModel}}, x:DataType=pageModels:EventDetailsPageModel}"
+                                                                CommandParameter="{Binding .}" />
+                                                        </Label.GestureRecognizers>
+                                                    </Label>
+                                                    <Label
+                                                        Text="{Binding When, Converter={StaticResource DateTimeConverter}}" />
+                                                    <Label Text="Nagranie nie jest gotowe."
+                                                           IsVisible="{Binding Converted, Converter={StaticResource InverseBooleanConverter}}"
+                                                           TextColor="{StaticResource Magenta}">
+                                                    </Label>
+                                                </VerticalStackLayout>
 
-                                        </Grid>
+                                                <controls:EditButton Grid.Column="1"
+                                                                     Command="{Binding RenameVideoCommand, Source={RelativeSource AncestorType={x:Type pageModels:EventDetailsPageModel}}, x:DataType=pageModels:EventDetailsPageModel}"
+                                                                     CommandParameter="{Binding Id}"
+                                                                     HorizontalOptions="End"
+                                                                     VerticalOptions="Center" />
+                                            </Grid>
+                                        </VerticalStackLayout>
                                     </Border>
                                 </DataTemplate>
                             </BindableLayout.ItemTemplate>

--- a/src/mobile/TB.DanceDance.Mobile/Pages/GroupVideosPage.xaml
+++ b/src/mobile/TB.DanceDance.Mobile/Pages/GroupVideosPage.xaml
@@ -28,10 +28,15 @@
                                     <Border Padding="10" Margin="0,10,0,0" IsEnabled="{Binding Converted}">
                                         <Grid>
                                             <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto"></ColumnDefinition>
                                                 <ColumnDefinition></ColumnDefinition>
                                                 <ColumnDefinition></ColumnDefinition>
                                             </Grid.ColumnDefinitions>
-                                        <VerticalStackLayout>
+                                        <controls:VideoThumbnail Grid.Column="0"
+                                            ThumbnailUrl="{Binding ThumbnailUrl}"
+                                            VerticalOptions="Center"
+                                            Margin="0,0,10,0" />
+                                        <VerticalStackLayout Grid.Column="1">
                                             <Label Text="{Binding Name}" FontSize="24">
                                                 <Label.GestureRecognizers>
                                                     <TapGestureRecognizer
@@ -46,7 +51,7 @@
                                                    >
                                             </Label>
                                         </VerticalStackLayout>
-                                            <controls:EditButton Grid.Column="1"
+                                            <controls:EditButton Grid.Column="2"
                                                                  Command="{Binding RenameVideoCommand, Source={RelativeSource AncestorType={x:Type pageModels:GroupVideosPageModel}}, x:DataType=pageModels:GroupVideosPageModel}"
                                                                  CommandParameter="{Binding Id}"
                                                                  HorizontalOptions="End"

--- a/src/mobile/TB.DanceDance.Mobile/Pages/GroupVideosPage.xaml
+++ b/src/mobile/TB.DanceDance.Mobile/Pages/GroupVideosPage.xaml
@@ -25,38 +25,39 @@
                             BindableLayout.ItemsSource="{Binding Videos}">
                             <BindableLayout.ItemTemplate>
                                 <DataTemplate x:DataType="models:Video">
-                                    <Border Padding="10" Margin="0,10,0,0" IsEnabled="{Binding Converted}">
-                                        <Grid>
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="Auto"></ColumnDefinition>
-                                                <ColumnDefinition></ColumnDefinition>
-                                                <ColumnDefinition></ColumnDefinition>
-                                            </Grid.ColumnDefinitions>
-                                        <controls:VideoThumbnail Grid.Column="0"
-                                            ThumbnailUrl="{Binding ThumbnailUrl}"
-                                            VerticalOptions="Center"
-                                            Margin="0,0,10,0" />
-                                        <VerticalStackLayout Grid.Column="1">
-                                            <Label Text="{Binding Name}" FontSize="24">
-                                                <Label.GestureRecognizers>
-                                                    <TapGestureRecognizer
-                                                        Command="{Binding NavigateToWatchVideoCommand, Source={RelativeSource AncestorType={x:Type pageModels:GroupVideosPageModel}}, x:DataType=pageModels:GroupVideosPageModel}"
-                                                        CommandParameter="{Binding .}" />
-                                                </Label.GestureRecognizers>
-                                            </Label>
-                                            <Label Text="{Binding When, Converter={StaticResource DateTimeConverter}}"/>
-                                            <Label Text="Nagranie nie jest gotowe."
-                                                   IsVisible="{Binding Converted, Converter={StaticResource InverseBooleanConverter}}"
-                                                   TextColor="{StaticResource Magenta}"
-                                                   >
-                                            </Label>
-                                        </VerticalStackLayout>
-                                            <controls:EditButton Grid.Column="2"
-                                                                 Command="{Binding RenameVideoCommand, Source={RelativeSource AncestorType={x:Type pageModels:GroupVideosPageModel}}, x:DataType=pageModels:GroupVideosPageModel}"
-                                                                 CommandParameter="{Binding Id}"
-                                                                 HorizontalOptions="End"
-                                                                 VerticalOptions="Center" />
+                                    <Border Padding="0" Margin="0,10,0,0" StrokeShape="RoundRectangle 8" IsEnabled="{Binding Converted}">
+                                        <VerticalStackLayout Spacing="0">
+                                            <controls:VideoThumbnail
+                                                ThumbnailUrl="{Binding ThumbnailUrl}"
+                                                HorizontalOptions="Fill" />
+
+                                            <Grid Padding="10">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition></ColumnDefinition>
+                                                    <ColumnDefinition Width="Auto"></ColumnDefinition>
+                                                </Grid.ColumnDefinitions>
+                                                <VerticalStackLayout Grid.Column="0">
+                                                    <Label Text="{Binding Name}" FontSize="24">
+                                                        <Label.GestureRecognizers>
+                                                            <TapGestureRecognizer
+                                                                Command="{Binding NavigateToWatchVideoCommand, Source={RelativeSource AncestorType={x:Type pageModels:GroupVideosPageModel}}, x:DataType=pageModels:GroupVideosPageModel}"
+                                                                CommandParameter="{Binding .}" />
+                                                        </Label.GestureRecognizers>
+                                                    </Label>
+                                                    <Label Text="{Binding When, Converter={StaticResource DateTimeConverter}}"/>
+                                                    <Label Text="Nagranie nie jest gotowe."
+                                                           IsVisible="{Binding Converted, Converter={StaticResource InverseBooleanConverter}}"
+                                                           TextColor="{StaticResource Magenta}"
+                                                           >
+                                                    </Label>
+                                                </VerticalStackLayout>
+                                                <controls:EditButton Grid.Column="1"
+                                                                     Command="{Binding RenameVideoCommand, Source={RelativeSource AncestorType={x:Type pageModels:GroupVideosPageModel}}, x:DataType=pageModels:GroupVideosPageModel}"
+                                                                     CommandParameter="{Binding Id}"
+                                                                     HorizontalOptions="End"
+                                                                     VerticalOptions="Center" />
                                             </Grid>
+                                        </VerticalStackLayout>
                                     </Border>
                                 </DataTemplate>
                             </BindableLayout.ItemTemplate>

--- a/src/mobile/TB.DanceDance.Mobile/Pages/MyVideosPage.xaml
+++ b/src/mobile/TB.DanceDance.Mobile/Pages/MyVideosPage.xaml
@@ -29,10 +29,15 @@
                                     <Border Padding="10" Margin="0,10,0,0" IsEnabled="{Binding Converted}">
                                         <Grid>
                                             <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto"></ColumnDefinition>
                                                 <ColumnDefinition></ColumnDefinition>
                                                 <ColumnDefinition></ColumnDefinition>
                                             </Grid.ColumnDefinitions>
-                                            <VerticalStackLayout>
+                                            <controls:VideoThumbnail Grid.Column="0"
+                                                ThumbnailUrl="{Binding ThumbnailUrl}"
+                                                VerticalOptions="Center"
+                                                Margin="0,0,10,0" />
+                                            <VerticalStackLayout Grid.Column="1">
                                                 <Label Text="{Binding Name}" FontSize="24">
                                                     <Label.GestureRecognizers>
                                                         <TapGestureRecognizer
@@ -48,7 +53,7 @@
                                                 </Label>
                                             </VerticalStackLayout>
 
-                                            <HorizontalStackLayout Grid.Column="1" HorizontalOptions="End" VerticalOptions="Center" Spacing="15">
+                                            <HorizontalStackLayout Grid.Column="2" HorizontalOptions="End" VerticalOptions="Center" Spacing="15">
                                                 <controls:ShareButton
                                                              Command="{Binding ShareVideoCommand, Source={RelativeSource AncestorType={x:Type pageModels:MyVideosPageModel}}, x:DataType=pageModels:MyVideosPageModel}"
                                                              CommandParameter="{Binding Id}"/>

--- a/src/mobile/TB.DanceDance.Mobile/Pages/MyVideosPage.xaml
+++ b/src/mobile/TB.DanceDance.Mobile/Pages/MyVideosPage.xaml
@@ -26,45 +26,45 @@
                         BindableLayout.ItemsSource="{Binding Videos}">
                             <BindableLayout.ItemTemplate>
                                 <DataTemplate x:DataType="models:Video">
-                                    <Border Padding="10" Margin="0,10,0,0" IsEnabled="{Binding Converted}">
-                                        <Grid>
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="Auto"></ColumnDefinition>
-                                                <ColumnDefinition></ColumnDefinition>
-                                                <ColumnDefinition></ColumnDefinition>
-                                            </Grid.ColumnDefinitions>
-                                            <controls:VideoThumbnail Grid.Column="0"
+                                    <Border Padding="0" Margin="0,10,0,0" StrokeShape="RoundRectangle 8" IsEnabled="{Binding Converted}">
+                                        <VerticalStackLayout Spacing="0">
+                                            <controls:VideoThumbnail
                                                 ThumbnailUrl="{Binding ThumbnailUrl}"
-                                                VerticalOptions="Center"
-                                                Margin="0,0,10,0" />
-                                            <VerticalStackLayout Grid.Column="1">
-                                                <Label Text="{Binding Name}" FontSize="24">
-                                                    <Label.GestureRecognizers>
-                                                        <TapGestureRecognizer
-                                                        Command="{Binding NavigateToWatchVideoCommand, Source={RelativeSource AncestorType={x:Type pageModels:MyVideosPageModel}}, x:DataType=pageModels:MyVideosPageModel}"
-                                                        CommandParameter="{Binding .}" />
-                                                    </Label.GestureRecognizers>
-                                                </Label>
-                                                <Label
-                                                Text="{Binding When, Converter={StaticResource DateTimeConverter}}" />
-                                                <Label Text="Nagranie nie jest gotowe."
-                                                   IsVisible="{Binding Converted, Converter={StaticResource InverseBooleanConverter}}"
-                                                   TextColor="{StaticResource Magenta}">
-                                                </Label>
-                                            </VerticalStackLayout>
+                                                HorizontalOptions="Fill" />
 
-                                            <HorizontalStackLayout Grid.Column="2" HorizontalOptions="End" VerticalOptions="Center" Spacing="15">
-                                                <controls:ShareButton
-                                                             Command="{Binding ShareVideoCommand, Source={RelativeSource AncestorType={x:Type pageModels:MyVideosPageModel}}, x:DataType=pageModels:MyVideosPageModel}"
-                                                             CommandParameter="{Binding Id}"/>
+                                            <Grid Padding="10">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition></ColumnDefinition>
+                                                    <ColumnDefinition Width="Auto"></ColumnDefinition>
+                                                </Grid.ColumnDefinitions>
+                                                <VerticalStackLayout Grid.Column="0">
+                                                    <Label Text="{Binding Name}" FontSize="24">
+                                                        <Label.GestureRecognizers>
+                                                            <TapGestureRecognizer
+                                                            Command="{Binding NavigateToWatchVideoCommand, Source={RelativeSource AncestorType={x:Type pageModels:MyVideosPageModel}}, x:DataType=pageModels:MyVideosPageModel}"
+                                                            CommandParameter="{Binding .}" />
+                                                        </Label.GestureRecognizers>
+                                                    </Label>
+                                                    <Label
+                                                    Text="{Binding When, Converter={StaticResource DateTimeConverter}}" />
+                                                    <Label Text="Nagranie nie jest gotowe."
+                                                       IsVisible="{Binding Converted, Converter={StaticResource InverseBooleanConverter}}"
+                                                       TextColor="{StaticResource Magenta}">
+                                                    </Label>
+                                                </VerticalStackLayout>
 
-                                                <controls:EditButton
-                                                             Command="{Binding RenameVideoCommand, Source={RelativeSource AncestorType={x:Type pageModels:MyVideosPageModel}}, x:DataType=pageModels:MyVideosPageModel}"
-                                                             CommandParameter="{Binding Id}"/>
+                                                <HorizontalStackLayout Grid.Column="1" HorizontalOptions="End" VerticalOptions="Center" Spacing="15">
+                                                    <controls:ShareButton
+                                                                 Command="{Binding ShareVideoCommand, Source={RelativeSource AncestorType={x:Type pageModels:MyVideosPageModel}}, x:DataType=pageModels:MyVideosPageModel}"
+                                                                 CommandParameter="{Binding Id}"/>
 
-                                            </HorizontalStackLayout>
+                                                    <controls:EditButton
+                                                                 Command="{Binding RenameVideoCommand, Source={RelativeSource AncestorType={x:Type pageModels:MyVideosPageModel}}, x:DataType=pageModels:MyVideosPageModel}"
+                                                                 CommandParameter="{Binding Id}"/>
 
-                                        </Grid>
+                                                </HorizontalStackLayout>
+                                            </Grid>
+                                        </VerticalStackLayout>
                                     </Border>
                                 </DataTemplate>
                             </BindableLayout.ItemTemplate>

--- a/src/tests/TB.DanceDance.Mobile.Tests/IntegrationTests/VideoMappingTests.cs
+++ b/src/tests/TB.DanceDance.Mobile.Tests/IntegrationTests/VideoMappingTests.cs
@@ -1,0 +1,95 @@
+using TB.DanceDance.API.Contracts.Features.Groups.Model;
+using TB.DanceDance.API.Contracts.Models;
+using TB.DanceDance.Mobile.Library.Data.Models;
+
+namespace TB.DanceDance.Mobile.Tests.IntegrationTests;
+
+public class VideoMappingTests
+{
+    [Fact]
+    public void MapFromApiResponse_MapsThumbnailUrl_FromVideoInformation()
+    {
+        var videos = new List<VideoInformation>
+        {
+            new()
+            {
+                VideoId = Guid.NewGuid(),
+                BlobId = "blob-1",
+                Name = "Recording",
+                RecordedDateTime = DateTime.UtcNow,
+                Converted = true,
+                ThumbnailUrl = "https://blob.local/thumbnails/blob-1.jpg",
+            },
+        };
+
+        var result = Video.MapFromApiResponse(videos);
+
+        Assert.Equal("https://blob.local/thumbnails/blob-1.jpg", result.Single().ThumbnailUrl);
+    }
+
+    [Fact]
+    public void MapFromApiResponse_MapsNullThumbnailUrl_FromVideoInformation()
+    {
+        var videos = new List<VideoInformation>
+        {
+            new()
+            {
+                VideoId = Guid.NewGuid(),
+                BlobId = "blob-1",
+                Name = "Recording",
+                RecordedDateTime = DateTime.UtcNow,
+                Converted = true,
+                ThumbnailUrl = null,
+            },
+        };
+
+        var result = Video.MapFromApiResponse(videos);
+
+        Assert.Null(result.Single().ThumbnailUrl);
+    }
+
+    [Fact]
+    public void MapFromApiResponse_MapsThumbnailUrl_FromVideoFromGroupInformation()
+    {
+        var videos = new List<VideoFromGroupInformation>
+        {
+            new()
+            {
+                VideoId = Guid.NewGuid(),
+                BlobId = "blob-2",
+                Name = "Group recording",
+                RecordedDateTime = DateTime.UtcNow,
+                Converted = true,
+                GroupId = Guid.NewGuid(),
+                GroupName = "Group",
+                ThumbnailUrl = "https://blob.local/thumbnails/blob-2.jpg",
+            },
+        };
+
+        var result = Video.MapFromApiResponse(videos);
+
+        Assert.Equal("https://blob.local/thumbnails/blob-2.jpg", result.Single().ThumbnailUrl);
+    }
+
+    [Fact]
+    public void MapFromApiResponse_MapsMissingThumbnailUrl_FromVideoFromGroupInformation()
+    {
+        var videos = new List<VideoFromGroupInformation>
+        {
+            new()
+            {
+                VideoId = Guid.NewGuid(),
+                BlobId = "blob-2",
+                Name = "Group recording",
+                RecordedDateTime = DateTime.UtcNow,
+                Converted = true,
+                GroupId = Guid.NewGuid(),
+                GroupName = "Group",
+            },
+        };
+
+        var result = Video.MapFromApiResponse(videos);
+
+        Assert.Null(result.Single().ThumbnailUrl);
+    }
+}


### PR DESCRIPTION
## Summary
- Map `ThumbnailUrl` (shipped via DD-41's stable SAS URIs) onto the mobile `Video` model from both `VideoInformation` and `VideoFromGroupInformation` API responses
- Render thumbnails as full-width card banners on My Videos, Group Videos, and Event Details lists, matching the web `video-card` layout (image on top, gradient-and-play placeholder for videos without a thumbnail, title/details below)
- Add a shared `VideoThumbnail` control: plain string-to-`UriImageSource` binding (no custom converter/auth needed — MAUI's disk caching works automatically off DD-41's stable URLs), `LinearGradientBrush` placeholder reproducing the web gradient (`#20314f` → `#2f6f73` → `#f0b35a`)
- Fix Android emulator thumbnail loading: when running the stack via `local_environment.dockercompose.yaml`, SAS URLs embed `host.docker.internal` (the API's blob endpoint host), which only resolves inside Docker containers, not on the emulator. Extended `NetworkAddressResolver`'s existing `localhost`/`127.0.0.1` → `10.0.2.2` rewrite to also cover `host.docker.internal` (DEBUG/Android only), and resolve it in `VideoThumbnail` before binding to `Image.Source` since `<Image>`/`UriImageSource` loads bypass the app's `HttpClient`/`DebuggingUrlHandler` pipeline

## Test plan
- [x] `Video.MapFromApiResponse` unit tests cover `ThumbnailUrl` mapping for both `VideoInformation` and `VideoFromGroupInformation`, including the null/missing case (`VideoMappingTests.cs`)
- [x] Verified on Android emulator against the local stack: real thumbnails render for converted videos, gradient-and-play placeholder renders for videos without thumbnails, and revisiting/scrolling lists reuses cached images

Closes DD-45 (DD-46 implementation, DD-47 tests, DD-48 local verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)