### PR TITLE
Fix upload progress, video seeking/navigation, event back-nav, and mobile background uploads

### DIFF
--- a/src/backend/Application/Features/Videos/Endpoints/Videos/StreamVideoEndpoint.cs
+++ b/src/backend/Application/Features/Videos/Endpoints/Videos/StreamVideoEndpoint.cs
@@ -43,6 +43,8 @@ public class StreamVideoEndpoint : EndpointWithoutRequest
             return await Send.UnauthorizedAsync(ct);
 
         var stream = await videoService.OpenStream(blobId, ct);
-        return await Send.StreamAsync(stream, contentType: "video/mp4", cancellation: ct);
+        // enableRangeProcessing lets the browser issue Range requests, which is
+        // what makes seeking forward (to not-yet-buffered positions) work.
+        return await Send.StreamAsync(stream, contentType: "video/mp4", enableRangeProcessing: true, cancellation: ct);
     }
 }

--- a/src/mobile/TB.DanceDance.Mobile.Library/Services/Network/UploadWorker.cs
+++ b/src/mobile/TB.DanceDance.Mobile.Library/Services/Network/UploadWorker.cs
@@ -88,10 +88,15 @@ public class UploadWorker : IDisposable
                 }
             }
 
-            uploadProgressChannel.Writer.TryComplete();
+            // Do NOT complete the channel: it is shared (a DI singleton) across
+            // upload sessions, so completing it would close it permanently and
+            // break progress reporting for every subsequent upload. End the
+            // monitor by cancelling instead, then deliver any tail messages it
+            // didn't drain before cancellation.
             Serilog.Log.Debug("Requesting cancellation on {token}.", mainLoopCanncellationTokenSource.Token.GetHashCode());
             await mainLoopCanncellationTokenSource.CancelAsync();
             await monitorProgressProcess;
+            DrainProgress();
 
             platformNotification?.UploadCompleteNotification();
 
@@ -120,7 +125,17 @@ public class UploadWorker : IDisposable
             // nothing to do
         }
     }
-    
+
+    /// <summary>
+    /// Forwards any progress messages still buffered after the monitor stopped,
+    /// so the final state isn't lost when the loop ends.
+    /// </summary>
+    private void DrainProgress()
+    {
+        while (uploadProgressChannel.Reader.TryRead(out var message))
+            platformNotification?.UploadProgressNotification(message.FileName, message.SendBytes, message.FileSize);
+    }
+
     private async Task Upload(VideosToUpload video, CancellationToken token)
     {
         try

--- a/src/mobile/TB.DanceDance.Mobile/Pages/WatchVideos/WatchVideoPageModel.cs
+++ b/src/mobile/TB.DanceDance.Mobile/Pages/WatchVideos/WatchVideoPageModel.cs
@@ -16,9 +16,8 @@ public partial class WatchVideoPageModel : ObservableObject, IEnteringAware<Watc
 
     private async Task LoadData(string videoBlobId)
     {
-        var path = Path.Combine(FileSystem.Current.CacheDirectory, videoBlobId + ".mp4");
-
 #if DEBUG
+        var path = Path.Combine(FileSystem.Current.CacheDirectory, videoBlobId + ".mp4");
         await using var stream = await apiClient.GetStream(videoBlobId);
         try
         {

--- a/src/mobile/TB.DanceDance.Mobile/TB.DanceDance.Mobile.csproj
+++ b/src/mobile/TB.DanceDance.Mobile/TB.DanceDance.Mobile.csproj
@@ -47,38 +47,38 @@
 	  <AndroidPackageFormat>aab</AndroidPackageFormat>
 	  <AndroidUseAapt2>True</AndroidUseAapt2>
 	  <AndroidCreatePackagePerAbi>False</AndroidCreatePackagePerAbi>
-	  <ApplicationVersion>21</ApplicationVersion>
+	  <ApplicationVersion>22</ApplicationVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-android|AnyCPU'">
 	  <AndroidPackageFormat>aab</AndroidPackageFormat>
 	  <AndroidUseAapt2>True</AndroidUseAapt2>
 	  <AndroidCreatePackagePerAbi>False</AndroidCreatePackagePerAbi>
-	  <ApplicationVersion>21</ApplicationVersion>
+	  <ApplicationVersion>22</ApplicationVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-ios|AnyCPU'">
-	  <ApplicationVersion>21</ApplicationVersion>
+	  <ApplicationVersion>22</ApplicationVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-maccatalyst|AnyCPU'">
-	  <ApplicationVersion>21</ApplicationVersion>
+	  <ApplicationVersion>22</ApplicationVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-windows10.0.19041.0|AnyCPU'">
-	  <ApplicationVersion>21</ApplicationVersion>
+	  <ApplicationVersion>22</ApplicationVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-ios|AnyCPU'">
-	  <ApplicationVersion>21</ApplicationVersion>
+	  <ApplicationVersion>22</ApplicationVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-maccatalyst|AnyCPU'">
-	  <ApplicationVersion>21</ApplicationVersion>
+	  <ApplicationVersion>22</ApplicationVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-windows10.0.19041.0|AnyCPU'">
-	  <ApplicationVersion>21</ApplicationVersion>
+	  <ApplicationVersion>22</ApplicationVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/my-dance.web/src/app/app.config.ts
+++ b/src/my-dance.web/src/app/app.config.ts
@@ -6,7 +6,7 @@ import {
   provideZonelessChangeDetection,
 } from '@angular/core';
 import { provideRouter, withComponentInputBinding } from '@angular/router';
-import { provideHttpClient, withFetch, withInterceptors } from '@angular/common/http';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { authInterceptor } from 'angular-auth-oidc-client';
 import { firstValueFrom } from 'rxjs';
 
@@ -20,7 +20,9 @@ export const appConfig: ApplicationConfig = {
     provideBrowserGlobalErrorListeners(),
     provideZonelessChangeDetection(),
     provideRouter(routes, withComponentInputBinding()),
-    provideHttpClient(withFetch(), withInterceptors([authInterceptor()])),
+    // XHR backend (the default) is required for upload-progress events;
+    // withFetch()'s backend cannot report bytes-sent progress.
+    provideHttpClient(withInterceptors([authInterceptor()])),
     provideRuntimeConfig(),
     provideAuthentication(),
     // Hydrate the session / process a sign-in redirect before routing starts.

--- a/src/my-dance.web/src/app/features/events/events.spec.ts
+++ b/src/my-dance.web/src/app/features/events/events.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
+import { provideRouter, Router } from '@angular/router';
 import { of, throwError } from 'rxjs';
 
 import { Events } from './events';
@@ -38,9 +38,12 @@ function createEventsFixture(overrides: {
     ],
   });
 
+  const router = TestBed.inject(Router);
+  const navigate = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
   const fixture = TestBed.createComponent(Events);
   fixture.detectChanges();
-  return { fixture, access, events, component: fixture.componentInstance };
+  return { fixture, access, events, navigate, component: fixture.componentInstance };
 }
 
 describe('Events', () => {
@@ -93,6 +96,40 @@ describe('Events', () => {
     expect(component.selected()?.id).toBe('e1');
     expect(component.videos()).toHaveLength(1);
     expect(component.videosLoading()).toBe(false);
+  });
+
+  it('select() pushes the event id into the URL so browser Back returns to the list', () => {
+    const { component, navigate } = createEventsFixture({});
+    component.select(GALA);
+    expect(navigate).toHaveBeenCalledWith(['/events'], { queryParams: { eventId: 'e1' } });
+  });
+
+  it('clearSelection() removes the event id from the URL', () => {
+    const { component, navigate } = createEventsFixture({});
+    component.select(GALA);
+    navigate.mockClear();
+
+    component.clearSelection();
+
+    expect(navigate).toHaveBeenCalledWith(['/events'], { queryParams: {} });
+  });
+
+  it('reflects the eventId query param (browser Back/Forward and deep links)', () => {
+    const getEventVideos = vi.fn(() => of({ items: [{ name: 'v1' }], totalCount: 1 }));
+    const { fixture, component, navigate } = createEventsFixture({ getEventVideos });
+
+    // Forward to the detail view via the URL — no extra history entry pushed.
+    fixture.componentRef.setInput('eventId', 'e1');
+    fixture.detectChanges();
+    expect(component.selected()?.id).toBe('e1');
+    expect(component.videos()).toHaveLength(1);
+    expect(navigate).not.toHaveBeenCalled();
+
+    // Browser Back clears the param and returns to the list.
+    fixture.componentRef.setInput('eventId', '');
+    fixture.detectChanges();
+    expect(component.selected()).toBeNull();
+    expect(navigate).not.toHaveBeenCalled();
   });
 
   it('select() exposes videosCanLoadMore when there are more items than the first page returned', () => {

--- a/src/my-dance.web/src/app/features/events/events.ts
+++ b/src/my-dance.web/src/app/features/events/events.ts
@@ -3,10 +3,13 @@ import {
   Component,
   DestroyRef,
   computed,
+  effect,
   inject,
+  input,
   signal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Router } from '@angular/router';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 
 import { AccessService } from '../../core/api/access.service';
@@ -157,8 +160,18 @@ const VIDEOS_PAGE_SIZE = 20;
 export class Events {
   private readonly access = inject(AccessService);
   private readonly events = inject(EventsService);
+  private readonly router = inject(Router);
   private readonly fb = inject(FormBuilder);
   private readonly destroyRef = inject(DestroyRef);
+
+  /**
+   * The selected event, carried in the URL (`/events?eventId=…`) so that the
+   * detail view is its own history entry — browser Back returns to the list.
+   * Bound from the query param via withComponentInputBinding().
+   */
+  readonly eventId = input<string>('');
+  /** The URL state we've already applied, so we don't reload on echoes. */
+  private syncedEventId = '';
 
   readonly loading = signal(true);
   readonly failed = signal(false);
@@ -189,6 +202,26 @@ export class Events {
 
   constructor() {
     this.load();
+    // Drive the detail view from the URL so browser Back/Forward and deep links
+    // work. Reacts to the bound query param and to events finishing loading.
+    effect(() => {
+      this.applyEventIdFromUrl(this.eventId(), this.items());
+    });
+  }
+
+  private applyEventIdFromUrl(id: string, events: readonly EventModel[]): void {
+    if (id === this.syncedEventId) {
+      return;
+    }
+    if (!id) {
+      this.resetDetail();
+      return;
+    }
+    const event = events.find((candidate) => candidate.id === id);
+    // If the events aren't loaded yet, this effect re-runs once they are.
+    if (event) {
+      this.loadDetail(event);
+    }
   }
 
   load(): void {
@@ -210,7 +243,16 @@ export class Events {
       });
   }
 
+  /** User picked an event from the list: render it and push a history entry. */
   select(event: EventModel): void {
+    this.loadDetail(event);
+    if (event.id) {
+      this.router.navigate(['/events'], { queryParams: { eventId: event.id } });
+    }
+  }
+
+  private loadDetail(event: EventModel): void {
+    this.syncedEventId = event.id ?? '';
     this.selected.set(event);
     if (!event.id) {
       return;
@@ -266,7 +308,14 @@ export class Events {
       });
   }
 
+  /** "Back to events" button: clear the URL so it lands on the list. */
   clearSelection(): void {
+    this.resetDetail();
+    this.router.navigate(['/events'], { queryParams: {} });
+  }
+
+  private resetDetail(): void {
+    this.syncedEventId = '';
     this.uploadModalOpen.set(false);
     this.selected.set(null);
     this.videos.set([]);

--- a/src/my-dance.web/src/app/features/videos/video-player.spec.ts
+++ b/src/my-dance.web/src/app/features/videos/video-player.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
+import { ViewportScroller } from '@angular/common';
 import { signal } from '@angular/core';
 import { of, throwError } from 'rxjs';
 
@@ -45,6 +46,7 @@ function createFixture(opts: {
     reportComment: vi.fn(() => of(void 0)),
   };
   const auth = { getAccessToken: vi.fn(() => of('token')), isAuthenticated: signal(true) };
+  const viewport = { scrollToPosition: vi.fn() };
 
   TestBed.configureTestingModule({
     imports: [VideoPlayer],
@@ -55,6 +57,7 @@ function createFixture(opts: {
       { provide: EventsService, useValue: events },
       { provide: CommentsService, useValue: comments },
       { provide: AuthService, useValue: auth },
+      { provide: ViewportScroller, useValue: viewport },
     ],
   });
 
@@ -63,7 +66,7 @@ function createFixture(opts: {
   if (opts.groupId) fixture.componentRef.setInput('groupId', opts.groupId);
   if (opts.eventId) fixture.componentRef.setInput('eventId', opts.eventId);
   fixture.detectChanges();
-  return { fixture, videos, groups, events, comments, auth, component: fixture.componentInstance };
+  return { fixture, videos, groups, events, comments, auth, viewport, component: fixture.componentInstance };
 }
 
 describe('VideoPlayer', () => {
@@ -114,6 +117,21 @@ describe('VideoPlayer', () => {
       const { component, events } = createFixture({ eventId: 'e1', getEventVideos });
       expect(events.getEventVideos).toHaveBeenCalledWith('e1', 1, 100);
       expect(component.siblings()).toHaveLength(1);
+    });
+
+    it('scrolls back to the top when switching to a sibling recording', () => {
+      const { fixture, viewport } = createFixture({
+        groupId: 'g1',
+        getVideosForGroup: vi.fn(() => of({ items: [{ videoId: 'a' }, { videoId: 'b' }] })),
+      });
+      // The component is reused across siblings; selecting one swaps the player
+      // in place, so it must scroll the viewport back up to the new video.
+      viewport.scrollToPosition.mockClear();
+
+      fixture.componentRef.setInput('blobId', 'blob2');
+      fixture.detectChanges();
+
+      expect(viewport.scrollToPosition).toHaveBeenCalledWith([0, 0]);
     });
 
     it('has no siblings without a scope', () => {

--- a/src/my-dance.web/src/app/features/videos/video-player.ts
+++ b/src/my-dance.web/src/app/features/videos/video-player.ts
@@ -9,6 +9,7 @@ import {
   signal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ViewportScroller } from '@angular/common';
 import { Observable, forkJoin } from 'rxjs';
 
 import { AuthService } from '../../core/auth/auth.service';
@@ -44,6 +45,7 @@ export class VideoPlayer {
   private readonly events = inject(EventsService);
   private readonly comments = inject(CommentsService);
   private readonly auth = inject(AuthService);
+  private readonly viewport = inject(ViewportScroller);
   private readonly destroyRef = inject(DestroyRef);
 
   readonly loading = signal(true);
@@ -79,6 +81,9 @@ export class VideoPlayer {
     effect(() => {
       this.blobId();
       this.load();
+      // The component is reused when switching between siblings, so the router
+      // doesn't reset scroll. Bring the player back into view at the top.
+      this.viewport.scrollToPosition([0, 0]);
     });
     effect(() => {
       this.groupId();

--- a/src/my-dance.web/src/app/shared/ui/video-card/video-card.spec.ts
+++ b/src/my-dance.web/src/app/shared/ui/video-card/video-card.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
+import { provideRouter, Router } from '@angular/router';
 
 import { VideoCard } from './video-card';
 import { VideoInformation } from '../../../core/api/api-models';
@@ -72,10 +72,30 @@ describe('VideoCard', () => {
     expect(watch?.getAttribute('href')).toBe('/videos/blob1?groupId=g1');
   });
 
+  it('opens the player when the thumbnail is clicked', async () => {
+    const fixture = await setup(CONVERTED, { queryParams: { groupId: 'g1' } });
+    const navigate = vi.spyOn(TestBed.inject(Router), 'navigateByUrl').mockResolvedValue(true);
+    const preview = fixture.nativeElement.querySelector('.video-card__preview') as HTMLElement;
+
+    expect(preview.classList).toContain('is-clickable');
+    preview.click();
+
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate.mock.calls[0][0].toString()).toBe('/videos/blob1?groupId=g1');
+  });
+
   it('shows a processing tag instead of Watch until the video is converted', async () => {
-    const el = (await setup({ ...CONVERTED, converted: false })).nativeElement as HTMLElement;
+    const fixture = await setup({ ...CONVERTED, converted: false });
+    const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector('a.button.is-primary')).toBeNull();
     expect(el.textContent).toContain('Processing');
+
+    // The thumbnail must not navigate while the recording is still processing.
+    const navigate = vi.spyOn(TestBed.inject(Router), 'navigateByUrl').mockResolvedValue(true);
+    const preview = el.querySelector('.video-card__preview') as HTMLElement;
+    expect(preview.classList).not.toContain('is-clickable');
+    preview.click();
+    expect(navigate).not.toHaveBeenCalled();
   });
 
   it('hides the Share action by default', async () => {

--- a/src/my-dance.web/src/app/shared/ui/video-card/video-card.ts
+++ b/src/my-dance.web/src/app/shared/ui/video-card/video-card.ts
@@ -18,6 +18,9 @@ import { LongDatePipe } from '../../format/long-date.pipe';
       <div
         class="video-card__preview"
         aria-hidden="true"
+        [class.is-clickable]="watchable()"
+        [routerLink]="watchable() ? ['/videos', video().blobId] : null"
+        [queryParams]="queryParams()"
         [style.--thumb]="thumbnailUrl() ? 'url(' + thumbnailUrl() + ')' : null"
         [class.has-thumbnail]="!!thumbnailUrl()"
       >
@@ -55,7 +58,7 @@ import { LongDatePipe } from '../../format/long-date.pipe';
         </p>
 
         <div class="buttons are-small video-card__actions">
-          @if (video().converted && video().blobId) {
+          @if (watchable()) {
             <a
               class="button is-primary video-card__watch"
               [routerLink]="['/videos', video().blobId]"
@@ -122,6 +125,10 @@ import { LongDatePipe } from '../../format/long-date.pipe';
 
     .video-card__preview.has-thumbnail {
       background: var(--thumb) center / cover no-repeat;
+    }
+
+    .video-card__preview.is-clickable {
+      cursor: pointer;
     }
 
     .video-card__preview::after {
@@ -264,6 +271,8 @@ export class VideoCard {
   readonly badge = input('');
   readonly share = output<VideoInformation>();
 
+  /** A recording is watchable once conversion has produced a playable blob. */
+  readonly watchable = computed(() => this.video().converted && !!this.video().blobId);
   readonly formattedDuration = computed(() => formatDuration(this.video().duration));
   readonly badgeTone = computed(() => getBadgeTone(this.badge()));
   readonly thumbnailUrl = computed(() => this.video().thumbnailUrl ?? null);

--- a/src/tests/TB.DanceDance.Mobile.Tests/IntegrationTests/UploadWorkerTests.cs
+++ b/src/tests/TB.DanceDance.Mobile.Tests/IntegrationTests/UploadWorkerTests.cs
@@ -177,4 +177,45 @@ public class UploadWorkerTests
 
         platform.Received().UploadProgressNotification("vid.mp4", 50, 100);
     }
+
+    [Fact(Timeout = 10000)]
+    public async Task Work_DoesNotComplete_SharedChannel()
+    {
+        // The channel is a DI singleton in the app: it must survive a session so
+        // later uploads can keep reporting progress.
+        var (worker, db, uploader, api, platform, channel) = CreateSut();
+
+        await worker.Work(TestContext.Current.CancellationToken);
+
+        Assert.False(channel.Reader.Completion.IsCompleted);
+        Assert.True(channel.Writer.TryWrite(
+            new UploadProgressEvent { FileName = "x", FileSize = 1, SendBytes = 1 }));
+    }
+
+    [Fact(Timeout = 10000)]
+    public async Task SecondSession_OnSameChannel_StillForwardsProgress()
+    {
+        // Mirrors production: each foreground-service start makes a new worker but
+        // shares the singleton channel. A first completed session must not break
+        // progress reporting for the next one.
+        var db = CreateDb();
+        var uploader = Substitute.For<IVideoUploader>();
+        var api = Substitute.For<IDanceHttpApiClient>();
+        var channel = Channel.CreateUnbounded<UploadProgressEvent>();
+
+        var firstWorker = new UploadWorker(db, uploader, api, channel);
+        firstWorker.SetPlatformNotification(Substitute.For<IPlatformNotification>());
+        await firstWorker.Work(TestContext.Current.CancellationToken);
+
+        var secondPlatform = Substitute.For<IPlatformNotification>();
+        var secondWorker = new UploadWorker(db, uploader, api, channel);
+        secondWorker.SetPlatformNotification(secondPlatform);
+        await channel.Writer.WriteAsync(
+            new UploadProgressEvent { FileName = "v2.mp4", FileSize = 100, SendBytes = 40 },
+            TestContext.Current.CancellationToken);
+
+        await secondWorker.Work(TestContext.Current.CancellationToken);
+
+        secondPlatform.Received().UploadProgressNotification("v2.mp4", 40, 100);
+    }
 }


### PR DESCRIPTION
## Overview

A batch of correctness fixes across the Angular web app and the MAUI (Android) mobile app, found while investigating upload and playback behaviour.

## Web (`src/my-dance.web`)

- **Upload progress never showed.** `HttpClient` was registered with `withFetch()`, whose backend cannot emit `HttpEventType.UploadProgress` (the Fetch API only reports download progress). Removed `withFetch()` so the default XHR backend is used, restoring per-file upload progress. Video streaming is unaffected — playback uses native `<video>` elements, not `HttpClient`.
- **Thumbnails are now clickable.** The video-card preview navigates to the player (same target as the Watch button) when the recording is watchable, and stays inert while still processing. The Watch button remains the accessible control, so no duplicate link is exposed to screen readers.
- **Forward seeking in the player.** The authenticated stream endpoint served the whole file as `200 OK` with no range support, so the slider couldn't jump to un-buffered positions. Enabled `enableRangeProcessing` on `StreamVideoEndpoint` (matching the shared-link endpoint) so the browser gets `206 Partial Content` and can seek anywhere.
- **Scroll-to-player when switching recordings.** Selecting a sibling reuses the `VideoPlayer` component, and the router doesn't reset scroll, so the new video loaded off-screen. The player now scrolls the viewport to the top on `blobId` change.
- **Browser Back returns to the event list.** The events page was a single `/events` route with an in-component master/detail toggle, so Back skipped past it. The selected event now lives in the URL (`/events?eventId=…`), making Back/Forward and deep links work.

## Mobile (`src/mobile`, Android)

- **Background uploads broke after the first one per app session.** `UploadWorker.Work` completed the writer of a **singleton** `Channel<UploadProgressEvent>`, permanently closing it. Subsequent uploads got no progress and threw unobserved `ChannelClosedException`s. The worker now ends its progress monitor via cancellation (as it already did) and drains tail messages instead of completing the shared channel.

## Tests

- Added/updated Vitest specs: thumbnail navigation (`video-card`), scroll-to-top (`video-player`), and event URL/back-nav (`events`). Full web suite: 304 passing.
- Added `UploadWorker` regression tests covering the shared-channel contract, including a two-session test that mirrors the production singleton-channel scenario.

## Reviewer notes

- `StreamVideoEndpoint` relies on `BlobClient.OpenReadAsync` returning a seekable stream with a known length (it does), which is what makes range processing work.
- Flagged but **not** changed in this PR (mobile, behavioural): direct upload bypasses the WiFi-only setting; no de-dup of queued files; the `AddSingleton<IPlatformNotification, UploadForegroundService>()` registration is effectively dead. Happy to follow up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
