### PR TITLE
Allow video owners to delete their videos (web + mobile) — DD-53

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"9019f1de-bbdd-4f13-97a4-3c6ed0bd2bde","pid":20544,"acquiredAt":1780936363072}

--- a/src/backend/Application/ApiRoutes.cs
+++ b/src/backend/Application/ApiRoutes.cs
@@ -28,6 +28,7 @@ public static class ApiRoutes
         public const string GetSingle = $"{Base}/{{blobId}}";
         public const string GetStream = $"{Base}/{{blobId}}/stream";
         public const string Rename = $"{Base}/{{videoId:guid}}/rename";
+        public const string Delete = $"{Base}/{{videoId:guid}}";
         public const string GetUploadUrl = $"{Base}/upload";
         public const string RefreshUploadUrl = $"{Base}/upload/{{videoId:guid}}";
         public const string UpdateCommentSettings = $"{Base}/{{videoId:guid}}/comment-settings";

--- a/src/backend/Application/ContractMappers.cs
+++ b/src/backend/Application/ContractMappers.cs
@@ -11,7 +11,7 @@ namespace Application;
 
 public static class ContractMappers
 {
-    public static VideoInformation MapToVideoInformation(Video video, string? thumbnailUrl)
+    public static VideoInformation MapToVideoInformation(Video video, string? thumbnailUrl, string? currentUserId = null)
     {
         return new VideoInformation()
         {
@@ -22,7 +22,8 @@ public static class ContractMappers
             RecordedDateTime = video.RecordedDateTime,
             Converted = video.Converted,
             CommentVisibility = (int)video.CommentVisibility,
-            ThumbnailUrl = thumbnailUrl
+            ThumbnailUrl = thumbnailUrl,
+            IsOwner = currentUserId != null && video.UploadedBy == currentUserId
         };
     }
 

--- a/src/backend/Application/Domain/Services/IBlobDataService.cs
+++ b/src/backend/Application/Domain/Services/IBlobDataService.cs
@@ -11,4 +11,9 @@ public interface IBlobDataService
     SharedBlob GetUploadSas(string? blobId = null);
     Task<bool> BlobExistsAsync(string blobId);
     Task<long> GetBlobSizeAsync(string blobId);
+
+    /// <summary>
+    /// Deletes the blob (including snapshots) if it exists. No-op when the blob is absent.
+    /// </summary>
+    Task DeleteAsync(string blobId, CancellationToken cancellationToken = default);
 }

--- a/src/backend/Application/Features/Events/Endpoints/ListEventVideosEndpoint.cs
+++ b/src/backend/Application/Features/Events/Endpoints/ListEventVideosEndpoint.cs
@@ -48,7 +48,7 @@ public class ListEventVideosEndpoint : Endpoint<ListEventVideosRequest, PagedRes
 
         var response = new PagedResponse<VideoInformation>
         {
-            Items = MapVideos(videos),
+            Items = MapVideos(videos, userId),
             TotalCount = totalCount,
             PageNumber = pageNumber,
             PageSize = pageSize,
@@ -57,10 +57,10 @@ public class ListEventVideosEndpoint : Endpoint<ListEventVideosRequest, PagedRes
         await Send.OkAsync(response, ct);
     }
 
-    private VideoInformation[] MapVideos(IReadOnlyCollection<Video> videos)
+    private VideoInformation[] MapVideos(IReadOnlyCollection<Video> videos, string currentUserId)
     {
         return videos
-            .Select(v => ContractMappers.MapToVideoInformation(v, thumbnailUrlService.GetThumbnailUrl(v.ThumbnailBlobId)))
+            .Select(v => ContractMappers.MapToVideoInformation(v, thumbnailUrlService.GetThumbnailUrl(v.ThumbnailBlobId), currentUserId))
             .ToArray();
     }
 }

--- a/src/backend/Application/Features/Groups/GroupService.cs
+++ b/src/backend/Application/Features/Groups/GroupService.cs
@@ -85,6 +85,7 @@ public class GroupService : IGroupService
                     RecordedDateTime = video.RecordedDateTime,
                     Converted = video.Converted,
                     VideoId = video.Id,
+                    IsOwner = video.UploadedBy == userId,
                 },
                 video.ThumbnailBlobId
             };
@@ -120,6 +121,7 @@ public class GroupService : IGroupService
                     RecordedDateTime = video.RecordedDateTime,
                     Converted = video.Converted,
                     VideoId = video.Id,
+                    IsOwner = video.UploadedBy == userId,
                 },
                 video.ThumbnailBlobId
             };

--- a/src/backend/Application/Features/Videos/Endpoints/Videos/DeleteVideoEndpoint.cs
+++ b/src/backend/Application/Features/Videos/Endpoints/Videos/DeleteVideoEndpoint.cs
@@ -1,0 +1,41 @@
+using Application.Extensions;
+using FastEndpoints;
+
+namespace Application.Features.Videos.Endpoints.Videos;
+
+public class DeleteVideoEndpoint : EndpointWithoutRequest
+{
+    private readonly IVideoService videoService;
+
+    public DeleteVideoEndpoint(IVideoService videoService)
+    {
+        this.videoService = videoService;
+    }
+
+    public override void Configure()
+    {
+        Delete(ApiRoutes.Video.Delete);
+        Policies(ApiScopes.Read);
+    }
+
+    public override async Task HandleAsync(CancellationToken ct)
+    {
+        var userId = User.GetSubject();
+        var videoId = Route<Guid>("videoId");
+
+        var result = await videoService.DeleteVideoAsync(videoId, userId, ct);
+
+        switch (result)
+        {
+            case DeleteVideoResult.NotFound:
+                await Send.NotFoundAsync(ct);
+                break;
+            case DeleteVideoResult.Forbidden:
+                await Send.ForbiddenAsync(ct);
+                break;
+            default:
+                await Send.NoContentAsync(ct);
+                break;
+        }
+    }
+}

--- a/src/backend/Application/Features/Videos/Endpoints/Videos/ListMyVideosEndpoint.cs
+++ b/src/backend/Application/Features/Videos/Endpoints/Videos/ListMyVideosEndpoint.cs
@@ -28,11 +28,12 @@ public class ListMyVideosEndpoint : Endpoint<ListMyVideosRequest, PagedResponse<
         var pageNumber = req.NormalizedPage;
         var pageSize = req.NormalizedPageSize;
 
-        var query = accessService.GetUserPrivateVideosQuery(User.GetSubject());
+        var userId = User.GetSubject();
+        var query = accessService.GetUserPrivateVideosQuery(userId);
         var (videos, totalCount) = await query.ToPagedResultAsync(pageNumber, pageSize, ct);
 
         var videoInformation = videos
-            .Select(v => ContractMappers.MapToVideoInformation(v, thumbnailUrlService.GetThumbnailUrl(v.ThumbnailBlobId)))
+            .Select(v => ContractMappers.MapToVideoInformation(v, thumbnailUrlService.GetThumbnailUrl(v.ThumbnailBlobId), userId))
             .ToArray();
 
         await Send.OkAsync(new PagedResponse<VideoInformation>

--- a/src/backend/Application/Features/Videos/Endpoints/Videos/VideoInformationEndpoint.cs
+++ b/src/backend/Application/Features/Videos/Endpoints/Videos/VideoInformationEndpoint.cs
@@ -33,7 +33,7 @@ public class VideoInformationEndpoint : EndpointWithoutRequest<VideoInformationR
             await Send.NotFoundAsync(cancellation: ct);
         else
         {
-            var results = ContractMappers.MapToVideoInformation(info, thumbnailUrlService.GetThumbnailUrl(info.ThumbnailBlobId));
+            var results = ContractMappers.MapToVideoInformation(info, thumbnailUrlService.GetThumbnailUrl(info.ThumbnailBlobId), user);
             await Send.OkAsync(new VideoInformationResponse
             {
                 VideoInformation = results

--- a/src/backend/Application/Features/Videos/IVideoService.cs
+++ b/src/backend/Application/Features/Videos/IVideoService.cs
@@ -5,6 +5,19 @@ using TB.DanceDance.API.Contracts.Features.Videos;
 
 namespace Application.Features.Videos;
 
+/// <summary>
+/// Outcome of an owner-only video delete, mapped by the endpoint to 204 / 403 / 404.
+/// </summary>
+public enum DeleteVideoResult
+{
+    /// <summary>No video exists with the given id.</summary>
+    NotFound,
+    /// <summary>The video exists but the requesting user is not its uploader.</summary>
+    Forbidden,
+    /// <summary>The video, its related rows and blobs were removed.</summary>
+    Deleted
+}
+
 public interface IVideoService
 {
     Task<Stream> OpenStream(string blobName, CancellationToken cancellationToken);
@@ -24,4 +37,15 @@ public interface IVideoService
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>True if updated successfully, false if not found or unauthorized</returns>
     Task<bool> UpdateCommentVisibilityAsync(Guid videoId, string userId, CommentVisibility commentVisibility, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Permanently deletes a video the user owns: the <see cref="Video"/> row (cascading to its
+    /// <c>SharedWith</c>, <c>Comment</c>, <c>SharedLink</c> and <c>VideoMetadata</c> rows) and all three
+    /// associated blobs (source, converted and thumbnail). Only the uploader may delete.
+    /// </summary>
+    /// <param name="videoId">The video ID.</param>
+    /// <param name="userId">The ID of the user requesting the delete (must be the uploader).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The delete outcome (deleted, forbidden, or not found).</returns>
+    Task<DeleteVideoResult> DeleteVideoAsync(Guid videoId, string userId, CancellationToken cancellationToken);
 }

--- a/src/backend/Application/Features/Videos/VideoService.cs
+++ b/src/backend/Application/Features/Videos/VideoService.cs
@@ -13,6 +13,8 @@ public class VideoService : IVideoService
 {
     private readonly IApplicationContext dbContext;
     private readonly IBlobDataService blobService;
+    private readonly IBlobDataService sourceBlobService;
+    private readonly IBlobDataService thumbnailBlobService;
     private readonly IVideoUploaderService videoUploaderService;
     private readonly IAccessService accessService;
 
@@ -25,6 +27,8 @@ public class VideoService : IVideoService
     {
         this.dbContext = dbContext;
         blobService = blobServiceFactory.GetBlobDataService(BlobContainer.Videos);
+        sourceBlobService = blobServiceFactory.GetBlobDataService(BlobContainer.VideosToConvert);
+        thumbnailBlobService = blobServiceFactory.GetBlobDataService(BlobContainer.Thumbnails);
         this.videoUploaderService = videoUploaderService;
         this.accessService = accessService;
     }
@@ -153,5 +157,38 @@ public class VideoService : IVideoService
         video.CommentVisibility = commentVisibility;
         await dbContext.SaveChangesAsync(cancellationToken);
         return true;
+    }
+
+    public async Task<DeleteVideoResult> DeleteVideoAsync(Guid videoId, string userId, CancellationToken cancellationToken)
+    {
+        var video = await dbContext.Videos
+            .FirstOrDefaultAsync(v => v.Id == videoId, cancellationToken);
+
+        if (video == null)
+            return DeleteVideoResult.NotFound;
+
+        // Only the uploader may delete — stricter than the access-based rename path.
+        if (video.UploadedBy != userId)
+            return DeleteVideoResult.Forbidden;
+
+        // Capture blob ids before the row is removed.
+        var sourceBlobId = video.SourceBlobId;
+        var convertedBlobId = video.BlobId;
+        var thumbnailBlobId = video.ThumbnailBlobId;
+
+        // Removing the Video row cascades to its SharedWith / Comment / SharedLink / VideoMetadata
+        // rows via the configured ON DELETE CASCADE foreign keys.
+        dbContext.Videos.Remove(video);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        // Blobs live outside the database, so clean them up explicitly. The three blobs live in
+        // separate containers; DeleteAsync is a no-op when a blob is missing (e.g. not yet converted).
+        await sourceBlobService.DeleteAsync(sourceBlobId, cancellationToken);
+        if (!string.IsNullOrEmpty(convertedBlobId))
+            await blobService.DeleteAsync(convertedBlobId, cancellationToken);
+        if (!string.IsNullOrEmpty(thumbnailBlobId))
+            await thumbnailBlobService.DeleteAsync(thumbnailBlobId, cancellationToken);
+
+        return DeleteVideoResult.Deleted;
     }
 }

--- a/src/backend/Infrastructure/Data/BlobStorage/BlobDataService.cs
+++ b/src/backend/Infrastructure/Data/BlobStorage/BlobDataService.cs
@@ -96,4 +96,10 @@ public class BlobDataService : IBlobDataService
         var properties = await blobClient.GetPropertiesAsync();
         return properties.Value.ContentLength;
     }
+
+    public Task DeleteAsync(string blobId, CancellationToken cancellationToken = default)
+    {
+        var client = container.GetBlobClient(blobId);
+        return client.DeleteIfExistsAsync(DeleteSnapshotsOption.IncludeSnapshots, cancellationToken: cancellationToken);
+    }
 }

--- a/src/backend/TB.DanceDance.API.Contracts/Models/VideoInformation.cs
+++ b/src/backend/TB.DanceDance.API.Contracts/Models/VideoInformation.cs
@@ -12,5 +12,11 @@ namespace TB.DanceDance.API.Contracts.Models
         public bool Converted { get; set; }
         public int CommentVisibility { get; set; }
         public string? ThumbnailUrl { get; set; }
+
+        /// <summary>
+        /// True when the requesting user is the uploader of this video, i.e. the only user
+        /// allowed to delete it. Drives owner-only actions (e.g. Delete) in the clients.
+        /// </summary>
+        public bool IsOwner { get; set; }
     }
 }

--- a/src/mobile/TB.DanceDance.Mobile.Library/Data/Models/Video.cs
+++ b/src/mobile/TB.DanceDance.Mobile.Library/Data/Models/Video.cs
@@ -20,6 +20,9 @@ public record Video
     public bool Converted { get; set; } = false;
     public string? ThumbnailUrl { get; set; }
 
+    /// <summary>True when the current user uploaded this video, i.e. may delete it.</summary>
+    public bool IsOwner { get; set; }
+
 
     public static List<Video> MapFromApiResponse(IReadOnlyCollection<VideoFromGroupInformation>? videosResponse)
     {
@@ -36,6 +39,7 @@ public record Video
             BlobId = v.BlobId,
             Converted = v.Converted,
             ThumbnailUrl = v.ThumbnailUrl,
+            IsOwner = v.IsOwner,
         }).ToList();
     }
 
@@ -49,6 +53,7 @@ public record Video
             BlobId = r.BlobId,
             Converted = r.Converted,
             ThumbnailUrl = r.ThumbnailUrl,
+            IsOwner = r.IsOwner,
         }).ToList();
     }
 }

--- a/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/DanceHttpApiClient.cs
+++ b/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/DanceHttpApiClient.cs
@@ -32,6 +32,12 @@ public class DanceHttpApiClient : IDanceHttpApiClient
         response.EnsureSuccessStatusCode();
     }
 
+    public async Task DeleteVideoAsync(Guid videoId)
+    {
+        var response = await httpClient.DeleteAsync($"/api/videos/{videoId}");
+        response.EnsureSuccessStatusCode();
+    }
+
     public async Task<GetUserAccessResponse> GetUserAccesses()
     {
         var response = await httpClient.GetAsync("/api/videos/accesses/my");

--- a/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/IDanceHttpApiClient.cs
+++ b/src/mobile/TB.DanceDance.Mobile.Library/Services/DanceApi/IDanceHttpApiClient.cs
@@ -10,6 +10,7 @@ namespace TB.DanceDance.Mobile.Library.Services.DanceApi;
 public interface IDanceHttpApiClient
 {
     Task RenameVideoAsync(Guid videoId, string newName);
+    Task DeleteVideoAsync(Guid videoId);
     Task<GetUserAccessResponse> GetUserAccesses();
     Task RequestAccess(RequestAccessRequest accessRequest);
     Task<PagedResponse<VideoFromGroupInformation>> GetVideosFromGroups(int page, int pageSize);

--- a/src/mobile/TB.DanceDance.Mobile/Pages/Controls/DeleteButton.xaml
+++ b/src/mobile/TB.DanceDance.Mobile/Pages/Controls/DeleteButton.xaml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ImageButton xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        x:Class="TB.DanceDance.Mobile.Pages.Controls.DeleteButton"
+        Source="delete.png"
+        Aspect="Fill"
+        HeightRequest="20"
+        WidthRequest="20" />

--- a/src/mobile/TB.DanceDance.Mobile/Pages/Controls/DeleteButton.xaml.cs
+++ b/src/mobile/TB.DanceDance.Mobile/Pages/Controls/DeleteButton.xaml.cs
@@ -1,0 +1,9 @@
+namespace TB.DanceDance.Mobile.Pages.Controls;
+
+public partial class DeleteButton
+{
+    public DeleteButton()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/mobile/TB.DanceDance.Mobile/Pages/Events/EventDetailsPage.xaml
+++ b/src/mobile/TB.DanceDance.Mobile/Pages/Events/EventDetailsPage.xaml
@@ -57,6 +57,7 @@
                                                                      Command="{Binding RenameVideoCommand, Source={RelativeSource AncestorType={x:Type events:EventDetailsPageModel}}, x:DataType=events:EventDetailsPageModel}"
                                                                      CommandParameter="{Binding Id}" />
                                                     <controls:DeleteButton
+                                                                     IsVisible="{Binding IsOwner}"
                                                                      Command="{Binding DeleteVideoCommand, Source={RelativeSource AncestorType={x:Type events:EventDetailsPageModel}}, x:DataType=events:EventDetailsPageModel}"
                                                                      CommandParameter="{Binding Id}" />
                                                 </HorizontalStackLayout>

--- a/src/mobile/TB.DanceDance.Mobile/Pages/Events/EventDetailsPage.xaml
+++ b/src/mobile/TB.DanceDance.Mobile/Pages/Events/EventDetailsPage.xaml
@@ -52,11 +52,14 @@
                                                     </Label>
                                                 </VerticalStackLayout>
 
-                                                <controls:EditButton Grid.Column="1"
+                                                <HorizontalStackLayout Grid.Column="1" HorizontalOptions="End" VerticalOptions="Center" Spacing="15">
+                                                    <controls:EditButton
                                                                      Command="{Binding RenameVideoCommand, Source={RelativeSource AncestorType={x:Type events:EventDetailsPageModel}}, x:DataType=events:EventDetailsPageModel}"
-                                                                     CommandParameter="{Binding Id}"
-                                                                     HorizontalOptions="End"
-                                                                     VerticalOptions="Center" />
+                                                                     CommandParameter="{Binding Id}" />
+                                                    <controls:DeleteButton
+                                                                     Command="{Binding DeleteVideoCommand, Source={RelativeSource AncestorType={x:Type events:EventDetailsPageModel}}, x:DataType=events:EventDetailsPageModel}"
+                                                                     CommandParameter="{Binding Id}" />
+                                                </HorizontalStackLayout>
                                             </Grid>
                                         </VerticalStackLayout>
                                     </Border>

--- a/src/mobile/TB.DanceDance.Mobile/Pages/Events/EventDetailsPageModel.cs
+++ b/src/mobile/TB.DanceDance.Mobile/Pages/Events/EventDetailsPageModel.cs
@@ -72,6 +72,31 @@ public partial class EventDetailsPageModel : ObservableObject,
     }
 
     [RelayCommand]
+    private async Task DeleteVideo(Guid videoId)
+    {
+        try
+        {
+            var video = Videos.FirstOrDefault(r => r.Id == videoId);
+            if (video == null)
+                return;
+
+            var confirmed = await Shell.Current.CurrentPage.DisplayAlertAsync("Usuń nagranie",
+                $"Czy na pewno chcesz trwale usunąć „{video.Name}”? Usunięte zostaną również komentarze i linki do udostępnień.",
+                "Usuń", "Anuluj");
+
+            if (!confirmed)
+                return;
+
+            await apiClient.DeleteVideoAsync(videoId);
+            Videos.Remove(video);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Could not delete video");
+        }
+    }
+
+    [RelayCommand]
     private Task NavigateToUploadToEvent()
         => navigationService.GoToAsync(
             Navigation.Relative()

--- a/src/mobile/TB.DanceDance.Mobile/Pages/Groups/GroupVideosPage.xaml
+++ b/src/mobile/TB.DanceDance.Mobile/Pages/Groups/GroupVideosPage.xaml
@@ -51,11 +51,14 @@
                                                            >
                                                     </Label>
                                                 </VerticalStackLayout>
-                                                <controls:EditButton Grid.Column="1"
+                                                <HorizontalStackLayout Grid.Column="1" HorizontalOptions="End" VerticalOptions="Center" Spacing="15">
+                                                    <controls:EditButton
                                                                      Command="{Binding RenameVideoCommand, Source={RelativeSource AncestorType={x:Type groups:GroupVideosPageModel}}, x:DataType=groups:GroupVideosPageModel}"
-                                                                     CommandParameter="{Binding Id}"
-                                                                     HorizontalOptions="End"
-                                                                     VerticalOptions="Center" />
+                                                                     CommandParameter="{Binding Id}" />
+                                                    <controls:DeleteButton
+                                                                     Command="{Binding DeleteVideoCommand, Source={RelativeSource AncestorType={x:Type groups:GroupVideosPageModel}}, x:DataType=groups:GroupVideosPageModel}"
+                                                                     CommandParameter="{Binding Id}" />
+                                                </HorizontalStackLayout>
                                             </Grid>
                                         </VerticalStackLayout>
                                     </Border>

--- a/src/mobile/TB.DanceDance.Mobile/Pages/Groups/GroupVideosPage.xaml
+++ b/src/mobile/TB.DanceDance.Mobile/Pages/Groups/GroupVideosPage.xaml
@@ -56,6 +56,7 @@
                                                                      Command="{Binding RenameVideoCommand, Source={RelativeSource AncestorType={x:Type groups:GroupVideosPageModel}}, x:DataType=groups:GroupVideosPageModel}"
                                                                      CommandParameter="{Binding Id}" />
                                                     <controls:DeleteButton
+                                                                     IsVisible="{Binding IsOwner}"
                                                                      Command="{Binding DeleteVideoCommand, Source={RelativeSource AncestorType={x:Type groups:GroupVideosPageModel}}, x:DataType=groups:GroupVideosPageModel}"
                                                                      CommandParameter="{Binding Id}" />
                                                 </HorizontalStackLayout>

--- a/src/mobile/TB.DanceDance.Mobile/Pages/Groups/GroupVideosPageModel.cs
+++ b/src/mobile/TB.DanceDance.Mobile/Pages/Groups/GroupVideosPageModel.cs
@@ -96,6 +96,31 @@ public partial class GroupVideosPageModel : ObservableObject, IAppearingAware
     }
 
     [RelayCommand]
+    private async Task DeleteVideo(Guid videoId)
+    {
+        try
+        {
+            var video = Videos.FirstOrDefault(r => r.Id == videoId);
+            if (video == null)
+                return;
+
+            var confirmed = await Shell.Current.CurrentPage.DisplayAlertAsync("Usuń nagranie",
+                $"Czy na pewno chcesz trwale usunąć „{video.Name}”? Usunięte zostaną również komentarze i linki do udostępnień.",
+                "Usuń", "Anuluj");
+
+            if (!confirmed)
+                return;
+
+            await apiClient.DeleteVideoAsync(videoId);
+            Videos.Remove(video);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Could not delete video");
+        }
+    }
+
+    [RelayCommand]
     private Task NavigateToWatchVideo(Video video)
         => navigationService.GoToAsync(
             Navigation.Relative()

--- a/src/mobile/TB.DanceDance.Mobile/Pages/MyVideosPage.xaml
+++ b/src/mobile/TB.DanceDance.Mobile/Pages/MyVideosPage.xaml
@@ -63,6 +63,7 @@
                                                                  CommandParameter="{Binding Id}"/>
 
                                                     <controls:DeleteButton
+                                                                 IsVisible="{Binding IsOwner}"
                                                                  Command="{Binding DeleteVideoCommand, Source={RelativeSource AncestorType={x:Type pages:MyVideosPageModel}}, x:DataType=pages:MyVideosPageModel}"
                                                                  CommandParameter="{Binding Id}"/>
 

--- a/src/mobile/TB.DanceDance.Mobile/Pages/MyVideosPage.xaml
+++ b/src/mobile/TB.DanceDance.Mobile/Pages/MyVideosPage.xaml
@@ -62,6 +62,10 @@
                                                                  Command="{Binding RenameVideoCommand, Source={RelativeSource AncestorType={x:Type pages:MyVideosPageModel}}, x:DataType=pages:MyVideosPageModel}"
                                                                  CommandParameter="{Binding Id}"/>
 
+                                                    <controls:DeleteButton
+                                                                 Command="{Binding DeleteVideoCommand, Source={RelativeSource AncestorType={x:Type pages:MyVideosPageModel}}, x:DataType=pages:MyVideosPageModel}"
+                                                                 CommandParameter="{Binding Id}"/>
+
                                                 </HorizontalStackLayout>
                                             </Grid>
                                         </VerticalStackLayout>

--- a/src/mobile/TB.DanceDance.Mobile/Pages/MyVideosPageModel.cs
+++ b/src/mobile/TB.DanceDance.Mobile/Pages/MyVideosPageModel.cs
@@ -84,6 +84,31 @@ public partial class MyVideosPageModel : ObservableObject, IAppearingAware
     }
 
     [RelayCommand]
+    private async Task DeleteVideo(Guid videoId)
+    {
+        try
+        {
+            var video = Videos.FirstOrDefault(r => r.Id == videoId);
+            if (video == null)
+                return;
+
+            var confirmed = await Shell.Current.CurrentPage.DisplayAlertAsync("Usuń nagranie",
+                $"Czy na pewno chcesz trwale usunąć „{video.Name}”? Usunięte zostaną również komentarze i linki do udostępnień.",
+                "Usuń", "Anuluj");
+
+            if (!confirmed)
+                return;
+
+            await apiClient.DeleteVideoAsync(videoId);
+            Videos.Remove(video);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Could not delete video");
+        }
+    }
+
+    [RelayCommand]
     private async Task ShareVideo(Guid videoId)
     {
 

--- a/src/mobile/TB.DanceDance.Mobile/Resources/Images/delete.svg
+++ b/src/mobile/TB.DanceDance.Mobile/Resources/Images/delete.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 7H20" stroke="#D7263D" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10 11V17" stroke="#D7263D" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14 11V17" stroke="#D7263D" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5 7L6 20C6 20.5304 6.21071 21.0391 6.58579 21.4142C6.96086 21.7893 7.46957 22 8 22H16C16.5304 22 17.0391 21.7893 17.4142 21.4142C17.7893 21.0391 18 20.5304 18 20L19 7" stroke="#D7263D" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9 7V4C9 3.73478 9.10536 3.48043 9.29289 3.29289C9.48043 3.10536 9.73478 3 10 3H14C14.2652 3 14.5196 3.10536 14.7071 3.29289C14.8946 3.48043 15 3.73478 15 4V7" stroke="#D7263D" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/my-dance.web/src/app/core/api/api-models.ts
+++ b/src/my-dance.web/src/app/core/api/api-models.ts
@@ -25,6 +25,8 @@ export interface VideoInformation {
     converted?: boolean;
     commentVisibility?: number;
     thumbnailUrl?: string | undefined;
+    /** True when the current user uploaded this video (the only one who may delete it). */
+    isOwner?: boolean;
 }
 
 export interface PagedRequest {

--- a/src/my-dance.web/src/app/core/api/videos.service.spec.ts
+++ b/src/my-dance.web/src/app/core/api/videos.service.spec.ts
@@ -55,6 +55,13 @@ describe('VideosService', () => {
     req.flush(null);
   });
 
+  it('deleteVideo() DELETEs the url-encoded video id', () => {
+    service.deleteVideo('vid 1').subscribe();
+    const req = httpMock.expectOne(`${BASE}/api/videos/vid%201`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush(null);
+  });
+
   it('updateCommentSettings() POSTs the visibility to the comment-settings endpoint', () => {
     service.updateCommentSettings('vid1', { commentVisibility: 2 }).subscribe();
     const req = httpMock.expectOne(`${BASE}/api/videos/vid1/comment-settings`);

--- a/src/my-dance.web/src/app/core/api/videos.service.ts
+++ b/src/my-dance.web/src/app/core/api/videos.service.ts
@@ -32,6 +32,11 @@ export class VideosService {
     return this.api.post<void>(`/api/videos/${encodeURIComponent(videoId)}/rename`, request);
   }
 
+  /** Owner-only: permanently delete a recording and all of its associated data. */
+  deleteVideo(videoId: string): Observable<void> {
+    return this.api.delete<void>(`/api/videos/${encodeURIComponent(videoId)}`);
+  }
+
   /** Owner-only: change who may see this recording's comments. */
   updateCommentSettings(
     videoId: string,

--- a/src/my-dance.web/src/app/features/videos/my-videos.html
+++ b/src/my-dance.web/src/app/features/videos/my-videos.html
@@ -15,7 +15,9 @@
     [videos]="items()"
     emptyMessage="You haven’t uploaded any recordings yet."
     [shareable]="true"
+    [deletable]="true"
     (share)="openShare($event)"
+    (deleteVideo)="onDelete($event)"
   />
 
   @if (canLoadMore()) {

--- a/src/my-dance.web/src/app/features/videos/my-videos.spec.ts
+++ b/src/my-dance.web/src/app/features/videos/my-videos.spec.ts
@@ -111,4 +111,71 @@ describe('MyVideos', () => {
     c.closeShare();
     expect(c.shareOpen()).toBe(false);
   });
+
+  describe('delete', () => {
+    async function setupForDelete(
+      deleteVideo: (videoId: string) => Observable<void>,
+    ): Promise<{ component: MyVideos }> {
+      await TestBed.configureTestingModule({
+        imports: [MyVideos],
+        providers: [
+          provideRouter([]),
+          {
+            provide: VideosService,
+            useValue: {
+              getMyVideos: () =>
+                of({
+                  items: [
+                    { videoId: 'v1', name: 'A' },
+                    { videoId: 'v2', name: 'B' },
+                  ],
+                  totalCount: 2,
+                }),
+              deleteVideo,
+            },
+          },
+          { provide: SharingService, useValue: { getMySharedLinks: () => of({ links: [] }) } },
+        ],
+      }).compileComponents();
+
+      const fixture = TestBed.createComponent(MyVideos);
+      fixture.detectChanges();
+      return { component: fixture.componentInstance };
+    }
+
+    afterEach(() => vi.restoreAllMocks());
+
+    it('confirms, deletes, and drops the item from the list', async () => {
+      vi.spyOn(window, 'confirm').mockReturnValue(true);
+      const deleteVideo = vi.fn(() => of(void 0));
+      const { component } = await setupForDelete(deleteVideo);
+
+      component.onDelete({ videoId: 'v1', name: 'A' });
+
+      expect(deleteVideo).toHaveBeenCalledWith('v1');
+      expect(component.items().map((v) => v.videoId)).toEqual(['v2']);
+    });
+
+    it('is a no-op when the confirmation is dismissed', async () => {
+      vi.spyOn(window, 'confirm').mockReturnValue(false);
+      const deleteVideo = vi.fn(() => of(void 0));
+      const { component } = await setupForDelete(deleteVideo);
+
+      component.onDelete({ videoId: 'v1', name: 'A' });
+
+      expect(deleteVideo).not.toHaveBeenCalled();
+      expect(component.items().map((v) => v.videoId)).toEqual(['v1', 'v2']);
+    });
+
+    it('keeps the item when the delete request fails', async () => {
+      vi.spyOn(window, 'confirm').mockReturnValue(true);
+      const deleteVideo = vi.fn(() => throwError(() => new Error('boom')));
+      const { component } = await setupForDelete(deleteVideo);
+
+      component.onDelete({ videoId: 'v1', name: 'A' });
+
+      expect(deleteVideo).toHaveBeenCalledWith('v1');
+      expect(component.items().map((v) => v.videoId)).toEqual(['v1', 'v2']);
+    });
+  });
 });

--- a/src/my-dance.web/src/app/features/videos/my-videos.ts
+++ b/src/my-dance.web/src/app/features/videos/my-videos.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { VideosService } from '../../core/api/videos.service';
@@ -17,10 +18,12 @@ const PAGE_SIZE = 20;
 export class MyVideos {
   private readonly videos = inject(VideosService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly doc = inject(DOCUMENT);
 
   readonly loading = signal(true);
   readonly failed = signal(false);
   readonly items = signal<readonly VideoInformation[]>([]);
+  private readonly deletingId = signal<string | null>(null);
 
   readonly loadingMore = signal(false);
   readonly canLoadMore = signal(false);
@@ -87,5 +90,32 @@ export class MyVideos {
 
   closeShare(): void {
     this.shareOpen.set(false);
+  }
+
+  onDelete(video: VideoInformation): void {
+    const videoId = video.videoId;
+    if (!videoId || this.deletingId() === videoId) {
+      return;
+    }
+
+    const name = video.name || 'this recording';
+    const confirmed = this.doc.defaultView?.confirm(
+      `Delete “${name}”? This permanently removes the recording, its comments and any shared links.`,
+    );
+    if (!confirmed) {
+      return;
+    }
+
+    this.deletingId.set(videoId);
+    this.videos
+      .deleteVideo(videoId)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.items.update((items) => items.filter((v) => v.videoId !== videoId));
+          this.deletingId.set(null);
+        },
+        error: () => this.deletingId.set(null),
+      });
   }
 }

--- a/src/my-dance.web/src/app/features/videos/video-player.html
+++ b/src/my-dance.web/src/app/features/videos/video-player.html
@@ -43,6 +43,15 @@
         >
           Rename
         </button>
+        <button
+          type="button"
+          class="button is-small is-text has-text-danger ml-1"
+          aria-label="Delete recording"
+          [disabled]="deleting()"
+          (click)="deleteVideo()"
+        >
+          Delete
+        </button>
       </h1>
     }
     <p class="subtitle is-6 has-text-grey">

--- a/src/my-dance.web/src/app/features/videos/video-player.html
+++ b/src/my-dance.web/src/app/features/videos/video-player.html
@@ -43,15 +43,17 @@
         >
           Rename
         </button>
-        <button
-          type="button"
-          class="button is-small is-text has-text-danger ml-1"
-          aria-label="Delete recording"
-          [disabled]="deleting()"
-          (click)="deleteVideo()"
-        >
-          Delete
-        </button>
+        @if (video.isOwner) {
+          <button
+            type="button"
+            class="button is-small is-text has-text-danger ml-1"
+            aria-label="Delete recording"
+            [disabled]="deleting()"
+            (click)="deleteVideo()"
+          >
+            Delete
+          </button>
+        }
       </h1>
     }
     <p class="subtitle is-6 has-text-grey">

--- a/src/my-dance.web/src/app/features/videos/video-player.spec.ts
+++ b/src/my-dance.web/src/app/features/videos/video-player.spec.ts
@@ -181,6 +181,21 @@ describe('VideoPlayer', () => {
   describe('delete', () => {
     afterEach(() => vi.restoreAllMocks());
 
+    const deleteButton = (fixture: ComponentFixture<VideoPlayer>) =>
+      fixture.nativeElement.querySelector('button[aria-label="Delete recording"]') as
+        | HTMLButtonElement
+        | null;
+
+    it('shows the Delete button when the user owns the recording', () => {
+      const { fixture } = createFixture({ video: { ...CONVERTED, isOwner: true } });
+      expect(deleteButton(fixture)).not.toBeNull();
+    });
+
+    it('hides the Delete button when the user does not own the recording', () => {
+      const { fixture } = createFixture({ video: { ...CONVERTED, isOwner: false } });
+      expect(deleteButton(fixture)).toBeNull();
+    });
+
     it('confirms, deletes, and navigates back to the library', () => {
       vi.spyOn(window, 'confirm').mockReturnValue(true);
       const deleteVideo = vi.fn(() => of(void 0));

--- a/src/my-dance.web/src/app/features/videos/video-player.spec.ts
+++ b/src/my-dance.web/src/app/features/videos/video-player.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
+import { Router, provideRouter } from '@angular/router';
 import { signal } from '@angular/core';
 import { of, throwError } from 'rxjs';
 
@@ -22,6 +22,7 @@ function createFixture(opts: {
   video?: VideoInformation | null;
   getVideo?: ReturnType<typeof vi.fn>;
   renameVideo?: ReturnType<typeof vi.fn>;
+  deleteVideo?: ReturnType<typeof vi.fn>;
   getVideosForGroup?: ReturnType<typeof vi.fn>;
   getEventVideos?: ReturnType<typeof vi.fn>;
   getCommentsForVideo?: ReturnType<typeof vi.fn>;
@@ -33,6 +34,7 @@ function createFixture(opts: {
     getVideo: opts.getVideo ?? vi.fn(() => of({ videoInformation: video })),
     streamUrl: vi.fn(() => 'https://api/stream'),
     renameVideo: opts.renameVideo ?? vi.fn(() => of(void 0)),
+    deleteVideo: opts.deleteVideo ?? vi.fn(() => of(void 0)),
   };
   const groups = { getVideosForGroup: opts.getVideosForGroup ?? vi.fn(() => of({ items: [] })) };
   const events = { getEventVideos: opts.getEventVideos ?? vi.fn(() => of({ items: [] })) };
@@ -173,6 +175,48 @@ describe('VideoPlayer', () => {
       component.startRename();
       component.cancelRename();
       expect(component.editingName()).toBe(false);
+    });
+  });
+
+  describe('delete', () => {
+    afterEach(() => vi.restoreAllMocks());
+
+    it('confirms, deletes, and navigates back to the library', () => {
+      vi.spyOn(window, 'confirm').mockReturnValue(true);
+      const deleteVideo = vi.fn(() => of(void 0));
+      const { component } = createFixture({ deleteVideo });
+      const navigate = vi.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
+
+      component.deleteVideo();
+
+      expect(deleteVideo).toHaveBeenCalledWith('vid1');
+      expect(navigate).toHaveBeenCalledWith(['/videos/my']);
+      expect(component.deleting()).toBe(false);
+    });
+
+    it('is a no-op when the confirmation is dismissed', () => {
+      vi.spyOn(window, 'confirm').mockReturnValue(false);
+      const deleteVideo = vi.fn(() => of(void 0));
+      const { component } = createFixture({ deleteVideo });
+      const navigate = vi.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
+
+      component.deleteVideo();
+
+      expect(deleteVideo).not.toHaveBeenCalled();
+      expect(navigate).not.toHaveBeenCalled();
+    });
+
+    it('clears the in-flight flag and stays on the page when the delete fails', () => {
+      vi.spyOn(window, 'confirm').mockReturnValue(true);
+      const deleteVideo = vi.fn(() => throwError(() => new Error('boom')));
+      const { component } = createFixture({ deleteVideo });
+      const navigate = vi.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
+
+      component.deleteVideo();
+
+      expect(deleteVideo).toHaveBeenCalledWith('vid1');
+      expect(navigate).not.toHaveBeenCalled();
+      expect(component.deleting()).toBe(false);
     });
   });
 

--- a/src/my-dance.web/src/app/features/videos/video-player.ts
+++ b/src/my-dance.web/src/app/features/videos/video-player.ts
@@ -8,6 +8,8 @@ import {
   input,
   signal,
 } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { Router } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Observable, forkJoin } from 'rxjs';
 
@@ -44,6 +46,8 @@ export class VideoPlayer {
   private readonly events = inject(EventsService);
   private readonly comments = inject(CommentsService);
   private readonly auth = inject(AuthService);
+  private readonly router = inject(Router);
+  private readonly doc = inject(DOCUMENT);
   private readonly destroyRef = inject(DestroyRef);
 
   readonly loading = signal(true);
@@ -62,6 +66,7 @@ export class VideoPlayer {
   readonly editingName = signal(false);
   readonly nameDraft = signal('');
   readonly renaming = signal(false);
+  readonly deleting = signal(false);
 
   /** User-selected tab. Reads through `activeTab` to guard against stale `recordings` state when no siblings are loaded. */
   private readonly tabChoice = signal<SidebarTab>('recordings');
@@ -161,6 +166,35 @@ export class VideoPlayer {
           this.editingName.set(false);
         },
         error: () => this.renaming.set(false),
+      });
+  }
+
+  deleteVideo(): void {
+    const video = this.info();
+    const videoId = video?.videoId;
+    if (!videoId || this.deleting()) {
+      return;
+    }
+
+    const name = video?.name || 'this recording';
+    const confirmed = this.doc.defaultView?.confirm(
+      `Delete “${name}”? This permanently removes the recording, its comments and any shared links.`,
+    );
+    if (!confirmed) {
+      return;
+    }
+
+    this.deleting.set(true);
+    this.videos
+      .deleteVideo(videoId)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.deleting.set(false);
+          // The recording is gone — leave the player and return to the library.
+          this.router.navigate(['/videos/my']);
+        },
+        error: () => this.deleting.set(false),
       });
   }
 

--- a/src/my-dance.web/src/app/shared/ui/video-card/video-card.spec.ts
+++ b/src/my-dance.web/src/app/shared/ui/video-card/video-card.spec.ts
@@ -17,6 +17,7 @@ async function setup(
   video: VideoInformation,
   inputs: Partial<{
     shareable: boolean;
+    deletable: boolean;
     selected: boolean;
     queryParams: Record<string, string>;
     badge: string;
@@ -93,6 +94,26 @@ describe('VideoCard', () => {
     button.click();
 
     expect(emitted).toEqual([CONVERTED]);
+  });
+
+  it('shows the Delete action only when deletable and the user owns the video', async () => {
+    const notOwner = (await setup({ ...CONVERTED, isOwner: false }, { deletable: true }))
+      .nativeElement as HTMLElement;
+    expect(notOwner.querySelector('.video-card__delete')).toBeNull();
+
+    const owner = await setup({ ...CONVERTED, isOwner: true }, { deletable: true });
+    const button = owner.nativeElement.querySelector('.video-card__delete') as HTMLButtonElement;
+    expect(button.textContent).toContain('Delete');
+
+    const emitted: VideoInformation[] = [];
+    owner.componentInstance.deleteVideo.subscribe((v) => emitted.push(v));
+    button.click();
+    expect(emitted).toEqual([{ ...CONVERTED, isOwner: true }]);
+  });
+
+  it('hides the Delete action when not deletable even for the owner', async () => {
+    const el = (await setup({ ...CONVERTED, isOwner: true })).nativeElement as HTMLElement;
+    expect(el.querySelector('.video-card__delete')).toBeNull();
   });
 
   it('highlights the card when selected', async () => {

--- a/src/my-dance.web/src/app/shared/ui/video-card/video-card.ts
+++ b/src/my-dance.web/src/app/shared/ui/video-card/video-card.ts
@@ -74,6 +74,15 @@ import { LongDatePipe } from '../../format/long-date.pipe';
               Share
             </button>
           }
+          @if (deletable()) {
+            <button
+              type="button"
+              class="button is-danger is-light video-card__delete"
+              (click)="deleteVideo.emit(video())"
+            >
+              Delete
+            </button>
+          }
         </div>
       </div>
     </article>
@@ -247,7 +256,8 @@ import { LongDatePipe } from '../../format/long-date.pipe';
       color: currentColor;
     }
 
-    .video-card__share {
+    .video-card__share,
+    .video-card__delete {
       font-weight: 600;
     }
   `,
@@ -256,6 +266,8 @@ export class VideoCard {
   readonly video = input.required<VideoInformation>();
   /** Show the Share action (e.g. in the user's own library). */
   readonly shareable = input(false);
+  /** Show the Delete action (owner-only, e.g. in the user's own library). */
+  readonly deletable = input(false);
   /** Query params carried to the player to preserve the group/event scope. */
   readonly queryParams = input<Params>({});
   /** Highlight this card as the currently-playing recording. */
@@ -263,6 +275,7 @@ export class VideoCard {
   /** Optional contextual label shown above the title (e.g. group name). */
   readonly badge = input('');
   readonly share = output<VideoInformation>();
+  readonly deleteVideo = output<VideoInformation>();
 
   readonly formattedDuration = computed(() => formatDuration(this.video().duration));
   readonly badgeTone = computed(() => getBadgeTone(this.badge()));

--- a/src/my-dance.web/src/app/shared/ui/video-card/video-card.ts
+++ b/src/my-dance.web/src/app/shared/ui/video-card/video-card.ts
@@ -74,7 +74,7 @@ import { LongDatePipe } from '../../format/long-date.pipe';
               Share
             </button>
           }
-          @if (deletable()) {
+          @if (deletable() && video().isOwner) {
             <button
               type="button"
               class="button is-danger is-light video-card__delete"

--- a/src/my-dance.web/src/app/shared/ui/video-list/video-list.ts
+++ b/src/my-dance.web/src/app/shared/ui/video-list/video-list.ts
@@ -19,9 +19,11 @@ import { VideoCard } from '../video-card/video-card';
             <app-video-card
               [video]="video"
               [shareable]="shareable()"
+              [deletable]="deletable()"
               [queryParams]="queryParams()"
               [selected]="!!selectedBlobId() && video.blobId === selectedBlobId()"
               (share)="share.emit($event)"
+              (deleteVideo)="deleteVideo.emit($event)"
             />
           </div>
         }
@@ -33,12 +35,15 @@ export class VideoList {
   readonly videos = input.required<readonly VideoInformation[]>();
   readonly emptyMessage = input('No recordings yet.');
   readonly shareable = input(false);
+  /** Show a per-card Delete action (owner-only). */
+  readonly deletable = input(false);
   /** Scope carried to the player so it can show a sibling playlist. */
   readonly scopeGroupId = input<string>('');
   readonly scopeEventId = input<string>('');
   /** Highlight the currently-playing recording (blob id). */
   readonly selectedBlobId = input<string>('');
   readonly share = output<VideoInformation>();
+  readonly deleteVideo = output<VideoInformation>();
 
   readonly queryParams = computed<Params>(() => {
     if (this.scopeGroupId()) {

--- a/src/tests/TB.DanceDance.Mobile.Tests/IntegrationTests/DanceHttpApiClientTests.cs
+++ b/src/tests/TB.DanceDance.Mobile.Tests/IntegrationTests/DanceHttpApiClientTests.cs
@@ -60,6 +60,29 @@ public class DanceHttpApiClientTests : IDisposable
     }
 
     [Fact]
+    public async Task DeleteVideoAsync_DeletesSuccessfully()
+    {
+        var id = Guid.NewGuid();
+        server.Given(Request.Create().WithPath($"/api/videos/{id}").UsingDelete())
+            .RespondWith(Response.Create().WithStatusCode(204));
+
+        await client.DeleteVideoAsync(id);
+
+        var logs = server.FindLogEntries(Request.Create().WithPath($"/api/videos/{id}").UsingDelete());
+        Assert.Single(logs);
+    }
+
+    [Fact]
+    public async Task DeleteVideoAsync_ThrowsOnError()
+    {
+        var id = Guid.NewGuid();
+        server.Given(Request.Create().WithPath($"/api/videos/{id}").UsingDelete())
+            .RespondWith(Response.Create().WithStatusCode(403));
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => client.DeleteVideoAsync(id));
+    }
+
+    [Fact]
     public async Task GetUserAccesses_ReturnsContent_OrEmptyOnNull()
     {
         var obj = new GetUserAccessResponse

--- a/src/tests/TB.DanceDance.Tests/Features/Videos/ContractMappersTests.cs
+++ b/src/tests/TB.DanceDance.Tests/Features/Videos/ContractMappersTests.cs
@@ -1,0 +1,20 @@
+using Application;
+
+namespace TB.DanceDance.Tests.Features.Videos;
+
+public class ContractMappersTests
+{
+    [Fact]
+    public void MapToVideoInformation_MarksIsOwner_OnlyForTheUploader()
+    {
+        var video = new VideoDataBuilder().UploadedBy("user-1").Build();
+
+        var asOwner = ContractMappers.MapToVideoInformation(video, thumbnailUrl: null, currentUserId: "user-1");
+        var asOther = ContractMappers.MapToVideoInformation(video, thumbnailUrl: null, currentUserId: "user-2");
+        var anonymous = ContractMappers.MapToVideoInformation(video, thumbnailUrl: null, currentUserId: null);
+
+        Assert.True(asOwner.IsOwner);
+        Assert.False(asOther.IsOwner);
+        Assert.False(anonymous.IsOwner);
+    }
+}

--- a/src/tests/TB.DanceDance.Tests/Features/Videos/VideoServiceTests.cs
+++ b/src/tests/TB.DanceDance.Tests/Features/Videos/VideoServiceTests.cs
@@ -322,4 +322,133 @@ public class VideoServiceTests : BaseTestClass
     }
 
     #endregion
+
+    #region DeleteVideoAsync Tests
+
+    private async Task UploadBlobAsync(BlobContainer container, string blobId)
+    {
+        var svc = factory.GetBlobDataService(container);
+        await svc.Upload(blobId, new MemoryStream([1, 2, 3, 4]));
+    }
+
+    private Task<bool> BlobExistsAsync(BlobContainer container, string blobId)
+        => factory.GetBlobDataService(container).BlobExistsAsync(blobId);
+
+    [Fact]
+    public async Task DeleteVideoAsync_Owner_RemovesVideoRelatedRowsAndBlobs()
+    {
+        // Arrange: a fully populated video — shared-with, a shared link, an authenticated
+        // comment and an anonymous comment via the link, plus all three blobs.
+        var owner = new UserDataBuilder().Build();
+        var sourceBlobId = $"src-{Guid.NewGuid():N}";
+        var convertedBlobId = Guid.NewGuid().ToString();
+        var thumbnailBlobId = $"{Guid.NewGuid()}/thumbnail.jpg";
+
+        var video = new VideoDataBuilder()
+            .UploadedBy(owner)
+            .Converted()
+            .WithSourceBlobId(sourceBlobId)
+            .WithBlobId(convertedBlobId)
+            .WithThumbnailBlobId(thumbnailBlobId)
+            .Build();
+
+        var sharedWith = new SharedWith { Id = Guid.NewGuid(), VideoId = video.Id, UserId = owner.Id };
+        var link = new SharedLinkDataBuilder().ForVideo(video).SharedBy(owner).Build();
+        var userComment = new CommentDataBuilder().ForVideo(video).ByUser(owner).Build();
+        var anonComment = new CommentDataBuilder().ForVideo(video).ByAnonymous(link).Build();
+
+        SeedDbContext.AddRange(owner, video, sharedWith, link, userComment, anonComment);
+        await SeedDbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await UploadBlobAsync(BlobContainer.VideosToConvert, sourceBlobId);
+        await UploadBlobAsync(BlobContainer.Videos, convertedBlobId);
+        await UploadBlobAsync(BlobContainer.Thumbnails, thumbnailBlobId);
+
+        // Act
+        var result = await videoService.DeleteVideoAsync(video.Id, owner.Id, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(DeleteVideoResult.Deleted, result);
+
+        SeedDbContext.ChangeTracker.Clear();
+        Assert.False(await SeedDbContext.Videos.AnyAsync(v => v.Id == video.Id, TestContext.Current.CancellationToken));
+        Assert.False(await SeedDbContext.SharedWith.AnyAsync(s => s.VideoId == video.Id, TestContext.Current.CancellationToken));
+        Assert.False(await SeedDbContext.SharedLinks.AnyAsync(l => l.VideoId == video.Id, TestContext.Current.CancellationToken));
+        Assert.False(await SeedDbContext.Comments.AnyAsync(c => c.VideoId == video.Id, TestContext.Current.CancellationToken));
+
+        Assert.False(await BlobExistsAsync(BlobContainer.VideosToConvert, sourceBlobId));
+        Assert.False(await BlobExistsAsync(BlobContainer.Videos, convertedBlobId));
+        Assert.False(await BlobExistsAsync(BlobContainer.Thumbnails, thumbnailBlobId));
+    }
+
+    [Fact]
+    public async Task DeleteVideoAsync_NotOwner_ReturnsForbidden_AndKeepsEverything()
+    {
+        var owner = new UserDataBuilder().Build();
+        var otherUser = new UserDataBuilder().Build();
+        var sourceBlobId = $"src-{Guid.NewGuid():N}";
+        var convertedBlobId = Guid.NewGuid().ToString();
+
+        var video = new VideoDataBuilder()
+            .UploadedBy(owner)
+            .Converted()
+            .WithSourceBlobId(sourceBlobId)
+            .WithBlobId(convertedBlobId)
+            .Build();
+
+        SeedDbContext.AddRange(owner, otherUser, video);
+        await SeedDbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await UploadBlobAsync(BlobContainer.VideosToConvert, sourceBlobId);
+        await UploadBlobAsync(BlobContainer.Videos, convertedBlobId);
+
+        var result = await videoService.DeleteVideoAsync(video.Id, otherUser.Id, TestContext.Current.CancellationToken);
+
+        Assert.Equal(DeleteVideoResult.Forbidden, result);
+
+        SeedDbContext.ChangeTracker.Clear();
+        Assert.True(await SeedDbContext.Videos.AnyAsync(v => v.Id == video.Id, TestContext.Current.CancellationToken));
+        Assert.True(await BlobExistsAsync(BlobContainer.VideosToConvert, sourceBlobId));
+        Assert.True(await BlobExistsAsync(BlobContainer.Videos, convertedBlobId));
+    }
+
+    [Fact]
+    public async Task DeleteVideoAsync_UnknownVideo_ReturnsNotFound()
+    {
+        var user = new UserDataBuilder().Build();
+        SeedDbContext.Add(user);
+        await SeedDbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await videoService.DeleteVideoAsync(Guid.NewGuid(), user.Id, TestContext.Current.CancellationToken);
+
+        Assert.Equal(DeleteVideoResult.NotFound, result);
+    }
+
+    [Fact]
+    public async Task DeleteVideoAsync_UnconvertedVideo_DeletesWithoutConvertedOrThumbnailBlobs()
+    {
+        // A video that hasn't been converted yet has no BlobId/ThumbnailBlobId — only the source blob exists.
+        var owner = new UserDataBuilder().Build();
+        var sourceBlobId = $"src-{Guid.NewGuid():N}";
+
+        var video = new VideoDataBuilder()
+            .UploadedBy(owner)
+            .WithSourceBlobId(sourceBlobId)
+            .WithBlobId(null)
+            .Build();
+
+        SeedDbContext.AddRange(owner, video);
+        await SeedDbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await UploadBlobAsync(BlobContainer.VideosToConvert, sourceBlobId);
+
+        var result = await videoService.DeleteVideoAsync(video.Id, owner.Id, TestContext.Current.CancellationToken);
+
+        Assert.Equal(DeleteVideoResult.Deleted, result);
+        SeedDbContext.ChangeTracker.Clear();
+        Assert.False(await SeedDbContext.Videos.AnyAsync(v => v.Id == video.Id, TestContext.Current.CancellationToken));
+        Assert.False(await BlobExistsAsync(BlobContainer.VideosToConvert, sourceBlobId));
+    }
+
+    #endregion
 }


### PR DESCRIPTION
@
Implements **DD-53**: a videos uploader can permanently delete it from the web app and the MAUI mobile app. Covers DD-54 (implementation), DD-55 (tests), DD-56 (local verification).

## What changed

**Backend**
- `IBlobDataService.DeleteAsync` (+ Azure impl, `DeleteIfExistsAsync`, no-op when absent).
- `VideoService.DeleteVideoAsync(videoId, userId, ct)` → `DeleteVideoResult` (`Deleted`/`Forbidden`/`NotFound`): enforces `video.UploadedBy == userId`, removes the `Video` row (DB `ON DELETE CASCADE` cleans up `SharedWith`/`Comment`/`SharedLink`/`VideoMetadata` — verified in the model snapshot, **no migration**), then deletes the 3 blobs. The source/converted/thumbnail blobs live in **three different containers** (`videostoconvert`/`videos`/`thumbnails`), so the service now resolves all three blob services.
- `DeleteVideoEndpoint` — `DELETE api/videos/{videoId:guid}`, `Policies(Read)` → 204 / 403 / 404.

**Owner-only Delete visibility**
- Added `VideoInformation.IsOwner` (`UploadedBy == currentUser`), populated by the my-videos, event-videos, group-videos and single-video-info endpoints.
- The Delete action is shown only when `IsOwner` is true (the server still enforces 403 as the authoritative guard).

**Web (`src/my-dance.web`)**
- `VideosService.deleteVideo`; confirm-then-delete on the video player (navigates to `/videos/my` on success) and a per-card Delete on My recordings (`deletable` + `deleteVideo` threaded through `video-list`/`video-card`, gated on `isOwner`). Confirmation uses the injected `DOCUMENT.defaultView`.

**Mobile (`src/mobile`)**
- `IDanceHttpApiClient.DeleteVideoAsync`; `DeleteVideo` commands on the My/Group/Event video page models (DisplayAlert confirm → client → drop from collection); new `DeleteButton` control + `delete.svg`, with `IsVisible` bound to `IsOwner`.

## Tests
- **Backend integration** (Testcontainers Postgres + Azurite): owner delete removes the video + related rows + all 3 blobs; non-owner → forbidden, nothing deleted; unknown id → 404; unconverted video deletes with only its source blob. Plus a mapper unit test for `IsOwner`.
- **Web Vitest**: `deleteVideo` request; player + my-videos confirm→service→remove/navigate (and cancel/failure paths); card + player Delete-visibility specs. Full suite **310 passing**.
- **Mobile WireMock**: `DeleteVideoAsync` DELETEs and throws on error.

## Local verification (golden path)
Ran live against the docker stack as the seeded users:
- non-owner DELETE of another users video → **403**, video retained;
- owner DELETE → **204**, My recordings count drops, video gone;
- repeat DELETE → **404**;
- Azurite confirmed the deleted videos converted blob and thumbnail are removed;
- `isOwner` returns `true` for own videos and `false` for others over HTTP.

## Reviewer notes
- Mobile page-model commands arent unit-tested because the net10.0 test project cant reference the MAUI head project (same as the existing untested rename/share commands); the testable seam (the API client) is covered.
- No DB migration — hard delete introduces no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@