### PR TITLE
Skip not-fully-uploaded videos in the converter feed

### DIFF
--- a/src/backend/Application/Features/Videos/VideoUploaderService.cs
+++ b/src/backend/Application/Features/Videos/VideoUploaderService.cs
@@ -23,19 +23,24 @@ public class VideoUploaderService : IVideoUploaderService
 
     public async Task<Video?> GetNextVideoToTransformAsync(CancellationToken cancellationToken)
     {
-        var video = await danceDbContext.Videos
+        var candidates = await danceDbContext.Videos
             .Where(r => (r.LockedTill == null || r.LockedTill < DateTime.UtcNow) && r.Converted == false)
             .OrderByDescending(r => r.SharedDateTime)
-            .FirstOrDefaultAsync(cancellationToken);
+            .ToListAsync(cancellationToken);
 
-        if (video == null)
-            return null;
+        foreach (var video in candidates)
+        {
+            // A block blob is only visible once its block list is committed; an in-progress or
+            // interrupted upload reports as non-existent. So existence == fully uploaded.
+            if (!await videosToConvertBlobs.BlobExistsAsync(video.SourceBlobId))
+                continue; // not fully uploaded yet — leave unlocked so it's retried next poll
 
-        video.LockedTill = DateTime.SpecifyKind(DateTime.Now.AddDays(1), DateTimeKind.Utc);
+            video.LockedTill = DateTime.SpecifyKind(DateTime.Now.AddDays(1), DateTimeKind.Utc);
+            await danceDbContext.SaveChangesAsync(cancellationToken);
+            return video;
+        }
 
-        await danceDbContext.SaveChangesAsync(cancellationToken);
-
-        return video;
+        return null;
     }
 
     public async Task<bool> UpdateVideoInformation(Guid videoId, TimeSpan duration, DateTime recorded,

--- a/src/tests/TB.DanceDance.Tests/Features/Videos/VideoUploaderTests.cs
+++ b/src/tests/TB.DanceDance.Tests/Features/Videos/VideoUploaderTests.cs
@@ -60,6 +60,12 @@ public class VideoUploaderTests : BaseTestClass
         }
     }
 
+    private async Task UploadSourceBlob(string sourceBlobId)
+    {
+        var toConvert = factory.GetBlobDataService(BlobContainer.VideosToConvert);
+        await toConvert.Upload(sourceBlobId, new MemoryStream(new byte[] { 1, 2, 3 }));
+    }
+
     [Fact]
     public async Task GetNextVideoToTransformAsync_DoesNotReturnLockedOrConverted()
     {
@@ -103,6 +109,7 @@ public class VideoUploaderTests : BaseTestClass
 
         SeedDbContext.AddRange(user, vLocked, vConverted, vEligible);
         await SeedDbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+        await UploadSourceBlob(vEligible.SourceBlobId);
 
         var next = await uploaderService.GetNextVideoToTransformAsync(TestContext.Current.CancellationToken);
 
@@ -111,6 +118,63 @@ public class VideoUploaderTests : BaseTestClass
         Assert.NotNull(next.LockedTill);
         Assert.True(next.LockedTill!.Value > DateTime.UtcNow);
         Assert.Equal(DateTimeKind.Utc, next.LockedTill!.Value.Kind);
+    }
+
+    [Fact]
+    public async Task GetNextVideoToTransformAsync_SkipsVideo_WhenSourceBlobNotUploaded()
+    {
+        await MakeAllExistingVideosIneligible();
+        var user = new UserDataBuilder().Build();
+        // Eligible by DB state, but its source blob was never (fully) uploaded.
+        var v = new VideoDataBuilder().UploadedBy(user).SharedAt(DateTime.UtcNow.AddDays(5)).Build();
+        SeedDbContext.AddRange(user, v);
+        await SeedDbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var next = await uploaderService.GetNextVideoToTransformAsync(TestContext.Current.CancellationToken);
+
+        Assert.Null(next);
+    }
+
+    [Fact]
+    public async Task GetNextVideoToTransformAsync_ReturnsVideo_WhenSourceBlobUploaded()
+    {
+        await MakeAllExistingVideosIneligible();
+        var user = new UserDataBuilder().Build();
+        var v = new VideoDataBuilder().UploadedBy(user).SharedAt(DateTime.UtcNow.AddDays(5)).Build();
+        SeedDbContext.AddRange(user, v);
+        await SeedDbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+        await UploadSourceBlob(v.SourceBlobId);
+
+        var next = await uploaderService.GetNextVideoToTransformAsync(TestContext.Current.CancellationToken);
+
+        Assert.NotNull(next);
+        Assert.Equal(v.Id, next!.Id);
+        Assert.NotNull(next.LockedTill);
+        Assert.True(next.LockedTill!.Value > DateTime.UtcNow);
+    }
+
+    [Fact]
+    public async Task GetNextVideoToTransformAsync_SkipsUnuploaded_AndReturnsUploaded()
+    {
+        await MakeAllExistingVideosIneligible();
+        var user = new UserDataBuilder().Build();
+        // Newer candidate (sorts first) has no uploaded blob; older candidate is fully uploaded.
+        var newerNotUploaded = new VideoDataBuilder().UploadedBy(user).SharedAt(DateTime.UtcNow.AddDays(10)).Build();
+        var olderUploaded = new VideoDataBuilder().UploadedBy(user).SharedAt(DateTime.UtcNow.AddDays(5)).Build();
+        SeedDbContext.AddRange(user, newerNotUploaded, olderUploaded);
+        await SeedDbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+        await UploadSourceBlob(olderUploaded.SourceBlobId);
+
+        var next = await uploaderService.GetNextVideoToTransformAsync(TestContext.Current.CancellationToken);
+
+        Assert.NotNull(next);
+        Assert.Equal(olderUploaded.Id, next!.Id);
+
+        // The skipped, not-uploaded video must be left unlocked so it is retried on the next poll.
+        SeedDbContext.ChangeTracker.Clear();
+        var skipped = await SeedDbContext.Videos.AsNoTracking()
+            .FirstAsync(x => x.Id == newerNotUploaded.Id, TestContext.Current.CancellationToken);
+        Assert.Null(skipped.LockedTill);
     }
 
     [Fact]


### PR DESCRIPTION
## What

The converter daemon polls `GET /api/converter/videos` for the next video to convert. A `Video` row is created at **upload-URL request time** — before the client has finished pushing bytes to blob storage. [`GetNextVideoToTransformAsync`](src/backend/Application/Features/Videos/VideoUploaderService.cs) only filtered on `Converted == false` and the lock window, so the daemon received videos whose source blob was missing or only partially staged, and the download/convert step failed.

This PR filters those out: the service now walks the ordered candidates and returns the first video whose **source blob is committed**, skipping the rest **without locking them** so they're retried on the next poll (a 1-day lock would otherwise starve a video that finishes uploading seconds later).

## Why blob existence is the "fully uploaded" signal

Azure block blobs (the SDK chunks large uploads into staged blocks finished by a single **Commit Block List**) only become visible once the block list is committed. An in-progress or interrupted upload leaves only *uncommitted* blocks and reports as **non-existent** to `ExistsAsync`/Get Blob Properties. So `BlobExistsAsync(sourceBlobId) == true` ⇔ the upload was committed. This reuses the existing `BlobExistsAsync` helper — the same pattern already used by `UploadConvertedVideoAsync`/`PublishThumbnailAsync`. **No DB migration, no web/mobile client changes.**

## Note on the "404 → flag" ask

The original request also mentioned returning `200 OK` with a "nothing to convert" flag instead of `404`. That was **already implemented** — `VideoToTransformEndpoint` already returns `VideoToTransformResponse { VideoExists = false }` when the service returns `null` (the 404 predated the FastEndpoints migration). The same flag now also covers the case where everything pending is still uploading.

## Tests

`VideoUploaderTests`:
- Added a `UploadSourceBlob` helper + 3 new tests: skip when blob absent, return when blob uploaded, and skip an un-uploaded newer candidate to return an older uploaded one (asserting the skipped one stays unlocked).
- Updated `SkipsLockedAndConverted_AndLocksNewest` to upload the eligible video's source blob (it would otherwise be filtered out now).

Verified locally against Testcontainers/Azurite: `VideoUploaderTests` 25/25 pass; Converter daemon/client tests 15 pass / 1 pre-existing skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)