### PR TITLE
Split feature work into small per-subtask commits in planning skills

### DIFF
--- a/.claude/skills/feature-pickup/SKILL.md
+++ b/.claude/skills/feature-pickup/SKILL.md
@@ -4,8 +4,10 @@ description: >-
   Pick up a planned feature from YouTrack (project DD) and start working on it: fetch
   the issue (by ID or by browsing Backlog), check out a branch, move it into Develop and
   assign it, re-derive the implementation/test/verification plan from the issue and its
-  subtasks, set up the local stack, and advance it to Review once implementation and
-  tests land. Companion to the `feature-planning` skill. Triggers: "pick up DD-42",
+  subtasks, set up the local stack, then build it one subtask at a time — committing each
+  subtask in its own commit and marking that subtask Done in YouTrack — and advance the
+  parent to Review once implementation and tests land. Companion to the `feature-planning`
+  skill. Triggers: "pick up DD-42",
   "let's start working on the thumbnails feature", "what's next in the backlog",
   "start implementing this issue".
 ---
@@ -59,20 +61,32 @@ Use the `local-stack` skill to get a working environment before writing code:
 - Wait for seed data (`docker logs -f tbdanceInitializer`).
 - Fetch a token if the feature needs authenticated API calls.
 
-## 6. Build it
+## 6. Build it — one subtask at a time, commit + update status per subtask
 
-Work the subtasks in order — they mirror the natural sequence:
-1. **Implementation** — follow the plan from step 4.
+Work the subtasks in their dependency order. `feature-planning` splits the build into
+**several small implementation subtasks** (by layer/slice) plus a `Tests` subtask and a
+`Local setup / verification` subtask, so the natural sequence is:
+1. Each **`Implementation: <slice>`** subtask in order — follow the plan from step 4.
 2. **Tests** — add/extend tests per the `Tests` subtask (xunit/NSubstitute/WireMock +
    Testcontainers for backend, Vitest for `my-dance.web`, `TB.DanceDance.Mobile.Tests`
    for mobile).
 3. **Local setup / verification** — run the golden-path checklist from that subtask;
    use the `verify` skill to actually exercise the feature in the running stack.
 
-Commit as you go rather than batching everything into one final commit: once a
-subtask (or a coherent chunk of one — e.g. a layer of the implementation, a test file)
-is in a working state, stage just those files and commit with a message describing that
-slice. Small, focused commits make the eventual PR easier to review and give you safe
+**Treat each subtask as one unit of work, and close it out before starting the next:**
+1. Implement just that subtask.
+2. Get it into a working state (it builds; its tests pass where applicable).
+3. **Commit that subtask on its own** — stage only the files belonging to this subtask and
+   make a single focused commit whose message describes the slice and references the
+   subtask (e.g. `DD-44: backend transfer entities + migration`). One subtask → one commit;
+   don't batch multiple subtasks into a commit, and don't split one subtask across unrelated
+   commits.
+4. **Update that subtask's status in YouTrack** (`mcp__youtrack__update_issue`) to
+   `Stage: Done` right after its commit lands — automatically, the same way step 3 and
+   step 7 move the parent. This keeps the board in lockstep with the commit history so the
+   remaining work is always visible.
+
+Small, focused per-subtask commits make the eventual PR easier to review and give safe
 checkpoints to fall back to if a later change goes sideways.
 
 ## 7. Advance to Review

--- a/.claude/skills/feature-planning/SKILL.md
+++ b/.claude/skills/feature-planning/SKILL.md
@@ -3,8 +3,9 @@ name: feature-planning
 description: >-
   Plan a new feature with the user up to the point of hand-off: scope it through
   conversation, then draft and create linked YouTrack issues (parent feature +
-  Implementation/Tests/Local-setup subtasks, each written with enough direction to be
-  picked up cold) in project DD. Does NOT produce a technical implementation plan —
+  several small implementation subtasks split by layer/slice, plus Tests and
+  Local-setup subtasks, each written with enough direction to be picked up cold) in
+  project DD. Does NOT produce a technical implementation plan —
   that's `feature-pickup`'s job once active work begins, closer to when the plan will
   actually be acted on. Triggers: "let's plan a feature for X", "I want to add Y to the
   app", "help me scope out Z before I start", "create a youtrack item for this feature",
@@ -37,8 +38,9 @@ paragraph becomes the YouTrack description.
 
 ## 2. Draft YouTrack issues — project `DD` (key), don't create yet
 
-Structure: **one parent feature issue + linked subtasks** for `Implementation`, `Tests`,
-and `Local setup / verification`.
+Structure: **one parent feature issue + linked subtasks**. Always split the implementation
+across **several small implementation subtasks** rather than one monolithic `Implementation`
+issue, then add one `Tests` subtask and one `Local setup / verification` subtask.
 
 - Use `mcp__youtrack__create_issue` with `project: DD`. Known custom fields:
   `Stage` (Backlog → Develop → Review → Test → Staging → Done — start at **Backlog**) and
@@ -46,10 +48,17 @@ and `Local setup / verification`.
   if they don't care).
 - Write each subtask description with enough direction that someone picking it up cold —
   i.e. `feature-pickup` — can turn it into a step-by-step plan without re-litigating scope:
-  - **Implementation**: the concrete changes and which layers/areas they land in (map onto
-    `Domain`/`Application`/`Infrastructure`/`API`, `src/my-dance.web`, `src/mobile`,
-    converter daemon, DB migrations — whichever apply). Call out any new entity, migration,
-    or seed-data change explicitly.
+  - **Implementation (split into several small subtasks)**: never collapse the whole build
+    into one issue. Break it into the smallest coherent, independently reviewable slices —
+    each ideally its own PR — and create one subtask per slice (title them
+    `Implementation: <slice>`). Default split is by layer/area in dependency order, e.g.
+    backend domain + entity + EF migration; backend application/services; backend
+    API/endpoints + contracts; `src/my-dance.web` UI; `src/mobile`; converter daemon —
+    include only those a feature actually touches, and split a layer further if it's still
+    large (e.g. separate frontend screens). For each subtask give the concrete changes and
+    which layers/areas they land in, call out any new entity, migration, or seed-data change
+    explicitly, and note its dependency on earlier subtasks so they can be picked up in
+    order.
   - **Tests**: what needs covering and roughly where it lives (backend integration tests in
     `src/tests/TB.DanceDance.Tests` — xunit v3, NSubstitute, WireMock.Net, Testcontainers;
     mobile tests in `src/tests/TB.DanceDance.Mobile.Tests`; frontend Vitest specs co-located


### PR DESCRIPTION
## What changed

Updates the two feature-workflow skills so a feature's build is broken into small, independently reviewable units instead of one big lump.

**`feature-planning`** — now mandates splitting the implementation across **several small implementation subtasks** (one per layer/slice, in dependency order: e.g. backend domain+migration, backend service, backend API+contracts, frontend slices) rather than a single monolithic `Implementation` issue, plus the usual `Tests` and `Local setup / verification` subtasks. Updated the frontmatter description, the structure line, and the Implementation guidance.

**`feature-pickup`** — now treats each subtask as one unit of work: implement it, get it to a working state, **commit it on its own** (one subtask → one focused commit referencing the subtask), then **mark that subtask `Stage: Done` in YouTrack**. This keeps the board in lockstep with commit history. Updated the frontmatter description and section 6.

## Why

Per-subtask commits + status updates make the eventual PR easier to review, give safe checkpoints, and keep the YouTrack board an accurate reflection of progress.

## Reviewer notes

- Docs/skill-only change — no application code touched.
- These conventions were applied in this session to plan the "Transfer owned videos to another user via link" feature (DD-66 + 7 linked subtasks, including 5 implementation slices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)