### PR TITLE
Fill missing user names and email on authenticated requests

### DIFF
--- a/.claude/skills/feature-pickup/SKILL.md
+++ b/.claude/skills/feature-pickup/SKILL.md
@@ -32,11 +32,11 @@ turns that into checked-out code, an active plan, and a running local stack.
 
 ## 2. Branch
 
-- Propose a branch name following the repo's `feature/<short-name>` convention (derive
-  `<short-name>` from the issue title — short, kebab-case, no issue ID prefix; matches
+- Derive a branch name following the repo's `feature/<short-name>` convention
+  (`<short-name>` from the issue title — short, kebab-case, no issue ID prefix; matches
   existing branches like `feature/thumbnails`, `feature/commenting-videos`).
-- Confirm the name with the user, then create and check it out:
-  `git checkout -b feature/<short-name>`.
+- Create and check it out immediately — no confirmation needed:
+  `git checkout -b feature/<short-name>`. Just report the branch name as you do it.
 
 ## 3. Move the issue into Develop
 

--- a/src/authserver/Endpoints/Handlers/DevelopmentEndpoints/PostNewUserHandler.cs
+++ b/src/authserver/Endpoints/Handlers/DevelopmentEndpoints/PostNewUserHandler.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Microsoft.AspNetCore.Identity;
 using TB.Auth.Web.Identity;
 
@@ -15,6 +16,8 @@ public static class PostNewUserHandler
         var form = await context.Request.ReadFormAsync();
         var login = form["login"].ToString().Trim();
         var email = form["email"].ToString().Trim();
+        var firstName = form["firstName"].ToString().Trim();
+        var lastName = form["lastName"].ToString().Trim();
         var password = form["password"].ToString();
 
         if (string.IsNullOrWhiteSpace(login) || string.IsNullOrWhiteSpace(password))
@@ -35,6 +38,17 @@ public static class PostNewUserHandler
             var details = string.Join(" | ", result.Errors.Select(error => error.Description));
             return Results.Redirect($"/dev/users/new?error={Uri.EscapeDataString(details)}");
         }
+
+        var claims = new List<Claim>();
+        if (!string.IsNullOrWhiteSpace(firstName))
+            claims.Add(new Claim(ClaimTypes.GivenName, firstName));
+        if (!string.IsNullOrWhiteSpace(lastName))
+            claims.Add(new Claim(ClaimTypes.Surname, lastName));
+        if (!string.IsNullOrWhiteSpace(email))
+            claims.Add(new Claim(ClaimTypes.Email, email));
+
+        if (claims.Count > 0)
+            await userManager.AddClaimsAsync(user, claims);
 
         return Results.Redirect($"/dev/users/new?message={Uri.EscapeDataString($"User '{login}' created.")}");
     }

--- a/src/authserver/Endpoints/HtmlBuilder.cs
+++ b/src/authserver/Endpoints/HtmlBuilder.cs
@@ -79,6 +79,12 @@ public class HtmlBuilder
                    <label>Email (optional)</label>
                    <input name="email" autocomplete="email" />
                    <br />
+                   <label>First name (optional)</label>
+                   <input name="firstName" autocomplete="given-name" />
+                   <br />
+                   <label>Last name (optional)</label>
+                   <input name="lastName" autocomplete="family-name" />
+                   <br />
                    <label>Password</label>
                    <input type="password" name="password" autocomplete="new-password" />
                    <br />

--- a/src/backend/Application/DependencyInjection.cs
+++ b/src/backend/Application/DependencyInjection.cs
@@ -20,6 +20,8 @@ public static class DependencyInjection
         public IServiceCollection RegisterApplicationServices()
         {
 
+            services.AddMemoryCache();
+
             services
                 .AddScoped<ICommentService, CommentService>()
                 .AddScoped<IIdentityClient, IdentityClient>()

--- a/src/backend/Application/Features/AccessManagement/AccessManagementService.cs
+++ b/src/backend/Application/Features/AccessManagement/AccessManagementService.cs
@@ -58,7 +58,7 @@ public class AccessManagementService : IAccessManagementService
         {
             record.FirstName = user.FirstName;
             record.LastName = user.LastName;
-            user.Email = user.Email;
+            record.Email = user.Email;
         }
         else
         {
@@ -66,6 +66,38 @@ public class AccessManagementService : IAccessManagementService
         }
 
         return dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task FillMissingUserDataAsync(User user, CancellationToken cancellationToken)
+    {
+        var record = await dbContext.Users.FindAsync([user.Id], cancellationToken);
+
+        if (record is null)
+        {
+            dbContext.Users.Add(user);
+            await dbContext.SaveChangesAsync(cancellationToken);
+            return;
+        }
+
+        var changed = false;
+        if (string.IsNullOrEmpty(record.FirstName) && !string.IsNullOrEmpty(user.FirstName))
+        {
+            record.FirstName = user.FirstName;
+            changed = true;
+        }
+        if (string.IsNullOrEmpty(record.LastName) && !string.IsNullOrEmpty(user.LastName))
+        {
+            record.LastName = user.LastName;
+            changed = true;
+        }
+        if (string.IsNullOrEmpty(record.Email) && !string.IsNullOrEmpty(user.Email))
+        {
+            record.Email = user.Email;
+            changed = true;
+        }
+
+        if (changed)
+            await dbContext.SaveChangesAsync(cancellationToken);
     }
 
     private IQueryable<RequestedAccess> GetEventRequestsThatCanBeApprovedByUser(string userId)

--- a/src/backend/Application/Features/AccessManagement/IAccessManagementService.cs
+++ b/src/backend/Application/Features/AccessManagement/IAccessManagementService.cs
@@ -6,6 +6,7 @@ namespace Application.Features.AccessManagement;
 public interface IAccessManagementService
 {
     Task AddOrUpdateUserAsync(User user, CancellationToken cancellationToken);
+    Task FillMissingUserDataAsync(User user, CancellationToken cancellationToken);
     Task<bool> ApproveAccessRequest(Guid requestId, bool isGroup, string userId);
     Task<bool> DeclineAccessRequest(Guid requestId, bool isGroup, string userId, CancellationToken cancellationToken);
     Task<UserRequests> GetPendingUserRequests(string userId, CancellationToken cancellationToken);

--- a/src/backend/Application/Features/AccessManagement/UserProfileSyncMiddleware.cs
+++ b/src/backend/Application/Features/AccessManagement/UserProfileSyncMiddleware.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Features.AccessManagement;
+
+public class UserProfileSyncMiddleware(RequestDelegate next, IMemoryCache cache)
+{
+    public async Task InvokeAsync(
+        HttpContext context,
+        IAccessManagementService accessManagement,
+        IIdentityClient identityClient,
+        ILogger<UserProfileSyncMiddleware> logger)
+    {
+        if (context.User.Identity?.IsAuthenticated == true)
+        {
+            var userId = context.User.FindFirst("sub")?.Value;
+            if (!string.IsNullOrEmpty(userId) && !cache.TryGetValue(CacheKey(userId), out _))
+            {
+                try
+                {
+                    var authHeader = context.Request.Headers.Authorization.ToString();
+                    if (!string.IsNullOrEmpty(authHeader))
+                    {
+                        var token = authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)
+                            ? authHeader["Bearer ".Length..].Trim()
+                            : authHeader;
+
+                        var userData = await identityClient.GetNameAsync(token, context.RequestAborted);
+                        await accessManagement.FillMissingUserDataAsync(userData, context.RequestAborted);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "Failed to sync profile for user {UserId}", userId);
+                }
+                finally
+                {
+                    cache.Set(CacheKey(userId), true, TimeSpan.FromHours(1));
+                }
+            }
+        }
+
+        await next(context);
+    }
+
+    private static string CacheKey(string userId) => $"profile_synced:{userId}";
+}

--- a/src/backend/TB.DanceDance.API/Program.cs
+++ b/src/backend/TB.DanceDance.API/Program.cs
@@ -153,6 +153,7 @@ if (string.IsNullOrEmpty(noHttps) || !noHttps.Equals("true", StringComparison.Or
 
 app.UseAuthentication();
 app.UseAuthorization();
+app.UseMiddleware<UserProfileSyncMiddleware>();
 app.UseApplicationEndpoints();
 app.MapGet("policy/dancedanceapp", (IConfiguration config) =>
 {


### PR DESCRIPTION
## Summary

- **Dev user creation form** now collects optional first/last name and stores them as `GivenName`/`Surname` identity claims, so they flow into every subsequent JWT and get stored as proper names in the dance DB.
- **`FillMissingUserDataAsync`** fills empty `FirstName`/`LastName`/`Email` fields on an existing DB record without overwriting populated data.
- **`UserProfileSyncMiddleware`** runs after authentication on every request, calls `FillMissingUserDataAsync` from the currently authenticated JWT, and caches per-user-ID for 1 hour so the DB is touched at most once per user per hour.
- **Bug fix** in `AddOrUpdateUserAsync`: `user.Email = user.Email` was a no-op — changed to `record.Email = user.Email` so emails are now persisted on update.

The combination means any user with missing data in `access.Users` will have their record filled the first time they make an authenticated request, without touching data that's already there.

Also includes a small skill tweak: the `feature-pickup` skill now creates the feature branch automatically without prompting for confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)