### PR TITLE
Default group join date to the season start

### DIFF
--- a/src/backend/Application/Features/AccessManagement/AccessManagementService.cs
+++ b/src/backend/Application/Features/AccessManagement/AccessManagementService.cs
@@ -37,13 +37,22 @@ public class AccessManagementService : IAccessManagementService
         var pendingRequests = await dbContext.GroupAssigmentRequests.Where(r => r.UserId == user && r.Approved == null)
             .Select(r => r.GroupId)
             .ToArrayAsync(cancellationToken);
-        
+
+        var groupIds = groups.Select(g => g.groupId).ToArray();
+        var seasonStarts = await dbContext.Groups
+            .Where(g => groupIds.Contains(g.Id))
+            .ToDictionaryAsync(g => g.Id, g => g.SeasonStart, cancellationToken);
+
         var toSave = groups
             .Where(group => !pendingRequests.Contains(group.groupId))
             .Select(group => new GroupAssigmentRequest()
         {
             GroupId = group.groupId,
-            WhenJoined = group.joinedDate,
+            // An unspecified join date defaults to the group's season start, so a member sees
+            // the whole season by default. WhenJoined is a timestamptz column -> must be UTC.
+            WhenJoined = group.joinedDate == default && seasonStarts.TryGetValue(group.groupId, out var seasonStart)
+                ? DateTime.SpecifyKind(seasonStart.ToDateTime(TimeOnly.MinValue), DateTimeKind.Utc)
+                : group.joinedDate,
             UserId = user
         });
 

--- a/src/backend/Application/Features/AccessManagement/Endpoints/RequestAccessEndpoint.cs
+++ b/src/backend/Application/Features/AccessManagement/Endpoints/RequestAccessEndpoint.cs
@@ -32,12 +32,6 @@ public class RequestAccessEndpoint : Endpoint<RequestAccessRequest>
             return;
         }
 
-        if (req.Groups != null && req.Groups.Any(r => r.JoinedDate == default))
-        {
-            await Send.ErrorsAsync(cancellation: ct);
-            return;
-        }
-
         var user = User.GetSubject();
 
         var token = GetAccessTokenFromHeader();

--- a/src/my-dance.web/src/app/features/access/request-access.html
+++ b/src/my-dance.web/src/app/features/access/request-access.html
@@ -30,7 +30,7 @@
                 <input
                   type="checkbox"
                   [checked]="checkedGroups().has(group.id ?? '')"
-                  (change)="toggleGroup(group.id)"
+                  (change)="toggleGroup(group)"
                 />
                 {{ group.name }}
                 <span class="is-size-7 has-text-grey">({{ group.seasonStart | season: group.seasonEnd }})</span>
@@ -44,7 +44,7 @@
                       class="input is-small"
                       type="date"
                       [max]="today"
-                      [value]="groupDates()[group.id ?? ''] ?? today"
+                      [value]="groupDates()[group.id ?? ''] ?? seasonStartDate(group)"
                       (change)="setGroupDate(group.id ?? '', $any($event.target).value)"
                     />
                   </div>

--- a/src/my-dance.web/src/app/features/access/request-access.spec.ts
+++ b/src/my-dance.web/src/app/features/access/request-access.spec.ts
@@ -3,7 +3,7 @@ import { of, throwError } from 'rxjs';
 
 import { RequestAccess } from './request-access';
 import { AccessService } from '../../core/api/access.service';
-import { GetUserAccessResponse } from '../../core/api/api-models';
+import { GetUserAccessResponse, GroupModel } from '../../core/api/api-models';
 
 const DATE = new Date(2026, 0, 1);
 const FULL_ACCESS: GetUserAccessResponse = {
@@ -12,11 +12,14 @@ const FULL_ACCESS: GetUserAccessResponse = {
     events: [{ id: 'ea', name: 'Assigned event', date: DATE }],
   },
   available: {
-    groups: [{ id: 'g1', name: 'Salsa' }],
+    // seasonStart arrives from the API as an ISO string at runtime.
+    groups: [{ id: 'g1', name: 'Salsa', seasonStart: '2025-09-01T00:00:00' as unknown as Date }],
     events: [{ id: 'e1', name: 'Gala', date: DATE }],
   },
   pending: { groups: ['gp'], events: ['ep1', 'ep2'] },
 };
+
+const salsa = (): GroupModel => FULL_ACCESS.available!.groups![0];
 
 function createFixture(overrides: {
   getMyAccess?: ReturnType<typeof vi.fn>;
@@ -67,16 +70,16 @@ describe('RequestAccess', () => {
       expect(component.checkedEvents().size).toBe(0);
     });
 
-    it('defaults a group join date to today when first checked', () => {
+    it("defaults a group join date to the group's season start when first checked", () => {
       const { component } = createFixture({});
-      component.toggleGroup('g1');
+      component.toggleGroup(salsa());
       expect(component.checkedGroups().has('g1')).toBe(true);
-      expect(component.groupDates()['g1']).toBe(component.today);
+      expect(component.groupDates()['g1']).toBe('2025-09-01');
     });
 
     it('lets a group join date be overridden', () => {
       const { component } = createFixture({});
-      component.toggleGroup('g1');
+      component.toggleGroup(salsa());
       component.setGroupDate('g1', '2026-01-15');
       expect(component.groupDates()['g1']).toBe('2026-01-15');
     });
@@ -101,7 +104,7 @@ describe('RequestAccess', () => {
       const { component, access } = createFixture({ requestAccess });
 
       component.toggleEvent('e1');
-      component.toggleGroup('g1');
+      component.toggleGroup(salsa());
       component.setGroupDate('g1', '2026-03-01');
       component.submit();
 

--- a/src/my-dance.web/src/app/features/access/request-access.ts
+++ b/src/my-dance.web/src/app/features/access/request-access.ts
@@ -71,18 +71,32 @@ export class RequestAccess {
     this.checkedEvents.update((set) => toggle(set, id));
   }
 
-  toggleGroup(id: string | undefined): void {
+  toggleGroup(group: GroupModel): void {
+    const id = group.id;
     if (!id) {
       return;
     }
     this.checkedGroups.update((set) => toggle(set, id));
     if (this.checkedGroups().has(id) && !this.groupDates()[id]) {
-      this.setGroupDate(id, this.today);
+      this.setGroupDate(id, this.seasonStartDate(group));
     }
   }
 
   setGroupDate(id: string, date: string): void {
     this.groupDates.update((dates) => ({ ...dates, [id]: date }));
+  }
+
+  /**
+   * A group's season start as a `yyyy-MM-dd` string, used as the default join date so a member
+   * sees the whole season. Falls back to today when the group has no season start. The API
+   * returns `seasonStart` as an ISO string, so we slice it directly to avoid timezone drift.
+   */
+  seasonStartDate(group: GroupModel): string {
+    const raw = group.seasonStart as unknown as string | Date | undefined;
+    if (!raw) {
+      return this.today;
+    }
+    return typeof raw === 'string' ? raw.slice(0, 10) : new Date(raw).toISOString().slice(0, 10);
   }
 
   submit(): void {
@@ -92,13 +106,14 @@ export class RequestAccess {
     this.submitting.set(true);
 
     const dates = this.groupDates();
+    const groupsById = new Map(this.availableGroups().map((group) => [group.id ?? '', group]));
     this.access
       .requestAccess({
         events: [...this.checkedEvents()],
-        groups: [...this.checkedGroups()].map((id) => ({
-          id,
-          joinedDate: new Date(dates[id] ?? this.today),
-        })),
+        groups: [...this.checkedGroups()].map((id) => {
+          const fallback = groupsById.has(id) ? this.seasonStartDate(groupsById.get(id)!) : this.today;
+          return { id, joinedDate: new Date(dates[id] ?? fallback) };
+        }),
       })
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({

--- a/src/tests/TB.DanceDance.Tests/Features/AccessManagement/AccessManagementServiceTests.cs
+++ b/src/tests/TB.DanceDance.Tests/Features/AccessManagement/AccessManagementServiceTests.cs
@@ -72,6 +72,25 @@ public class AccessManagementServiceTests : BaseTestClass
     }
 
     [Fact]
+    public async Task SaveGroupsAssigmentRequests_DefaultsJoinDateToSeasonStart_WhenNotProvided()
+    {
+        var requestor = new UserDataBuilder().Build();
+        var group = new GroupDataBuilder()
+            .WithSeasonDates(new DateOnly(2024, 9, 1), new DateOnly(2025, 8, 31))
+            .Build();
+
+        SeedDbContext.AddRange(requestor, group);
+        await SeedDbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await service.SaveGroupsAssigmentRequests(requestor.Id,
+            [(group.Id, default)], TestContext.Current.CancellationToken);
+
+        var saved = SeedDbContext.GroupAssigmentRequests.Single(r => r.UserId == requestor.Id && r.GroupId == group.Id);
+        var expected = DateTime.SpecifyKind(group.SeasonStart.ToDateTime(TimeOnly.MinValue), DateTimeKind.Utc);
+        Assert.Equal(expected, saved.WhenJoined);
+    }
+
+    [Fact]
     public async Task AddOrUpdateUserAsync_AddsThenUpdatesUserNames()
     {
         var userB = new UserDataBuilder();


### PR DESCRIPTION
## What

When a user requests access to a seasonal group, the **"when joined"** date (`WhenJoined`) now defaults to the **group's season start** instead of today.

## Why

`WhenJoined` gates which videos a member can see — only videos recorded *after* they joined (`assignedTo.WhenJoined < video.RecordedDateTime`). Defaulting to *today* meant a new member of a season's group saw almost none of that season's videos. Defaulting to the season start makes the common case ("I'm a member of this season") work out of the box, while still letting the user pick a later date if they genuinely joined mid-season.

## Changes

**Frontend (`src/my-dance.web`, Request access screen)**
- Pre-fill the "When did you join?" date picker with the group's `seasonStart` instead of today. The picker stays editable.
- `seasonStart` arrives from the API as an ISO string, so it's sliced to `yyyy-MM-dd` directly to avoid timezone drift.

**Backend**
- `AccessManagementService.SaveGroupsAssigmentRequests`: when a request omits/zeroes the join date, fall back to the group's `SeasonStart`. Stored as `DateTimeKind.Utc` because `WhenJoined` is a `timestamp with time zone` column.
- `RequestAccessEndpoint`: removed the guard that rejected an empty join date — an omitted date now validly means "use the season start".

## Tests

- **Backend**: new `AccessManagementServiceTests.SaveGroupsAssigmentRequests_DefaultsJoinDateToSeasonStart_WhenNotProvided`. `AccessManagementServiceTests` — 12 passed.
- **Frontend**: updated `request-access.spec.ts` to assert the picker defaults to the season start. Full suite — 315 passed.

## Reviewer notes

- The default applies in both the frontend (pre-fill, overridable) and the backend (fallback) for defense in depth.
- The `NG8102` template warning on the `?? seasonStartDate(group)` fallback is pre-existing (the original `?? today` had the same shape) and the fallback is functionally needed — the runtime index can be `undefined` even though TS types it as `string`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)