### PR TITLE
Add generate-migration skill; fold tests into feature-planning subtasks

### DIFF
--- a/.claude/skills/feature-planning/SKILL.md
+++ b/.claude/skills/feature-planning/SKILL.md
@@ -3,9 +3,9 @@ name: feature-planning
 description: >-
   Plan a new feature with the user up to the point of hand-off: scope it through
   conversation, then draft and create linked YouTrack issues (parent feature +
-  several small implementation subtasks split by layer/slice, plus Tests and
-  Local-setup subtasks, each written with enough direction to be picked up cold) in
-  project DD. Does NOT produce a technical implementation plan —
+  several small implementation subtasks split by layer/slice — each covering its own
+  tests — plus a Local-setup/verification subtask, each written with enough direction to
+  be picked up cold) in project DD. Does NOT produce a technical implementation plan —
   that's `feature-pickup`'s job once active work begins, closer to when the plan will
   actually be acted on. Triggers: "let's plan a feature for X", "I want to add Y to the
   app", "help me scope out Z before I start", "create a youtrack item for this feature",
@@ -40,7 +40,10 @@ paragraph becomes the YouTrack description.
 
 Structure: **one parent feature issue + linked subtasks**. Always split the implementation
 across **several small implementation subtasks** rather than one monolithic `Implementation`
-issue, then add one `Tests` subtask and one `Local setup / verification` subtask.
+issue. **Each implementation subtask covers writing the tests for its own slice** (when that
+slice can be meaningfully tested in isolation) rather than deferring them to a separate
+`Tests` issue. Then add one `Local setup / verification` subtask. Do **not** create a
+standalone `Tests` subtask.
 
 - Use `mcp__youtrack__create_issue` with `project: DD`. Known custom fields:
   `Stage` (Backlog → Develop → Review → Test → Staging → Done — start at **Backlog**) and
@@ -58,11 +61,16 @@ issue, then add one `Tests` subtask and one `Local setup / verification` subtask
     large (e.g. separate frontend screens). For each subtask give the concrete changes and
     which layers/areas they land in, call out any new entity, migration, or seed-data change
     explicitly, and note its dependency on earlier subtasks so they can be picked up in
-    order.
-  - **Tests**: what needs covering and roughly where it lives (backend integration tests in
+    order. When a slice adds or changes a DB schema, say that its migration is generated with
+    the `generate-migration` skill (`add-migration.ps1`, revertable via `remove-migration.ps1`)
+    against a throwaway Postgres container — never hand-written. **Each implementation subtask must also spell out the tests for its own slice**:
+    what needs covering and roughly where it lives (backend integration tests in
     `src/tests/TB.DanceDance.Tests` — xunit v3, NSubstitute, WireMock.Net, Testcontainers;
     mobile tests in `src/tests/TB.DanceDance.Mobile.Tests`; frontend Vitest specs co-located
-    in `src/my-dance.web`), plus any new fixtures/seed data/stubs anticipated.
+    in `src/my-dance.web`), plus any new fixtures/seed data/stubs anticipated. Only omit
+    tests for a slice that genuinely can't be tested in isolation (e.g. a scaffolding- or
+    migration-only change with no behaviour yet) — and when you do, say so explicitly in the
+    subtask. Never split testing out into its own subtask.
   - **Local setup / verification**: the concrete "I'll know it works when..." golden-path
     check — what to click through or call (`curl`/`.http`/UI flow), which `local-stack`
     operations are involved (rebuild a container, reset DB/blobs, get a token, tail logs),

--- a/.claude/skills/generate-migration/SKILL.md
+++ b/.claude/skills/generate-migration/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: generate-migration
+description: >-
+  Generate or revert an EF Core migration for the backend DanceDbContext entirely
+  through a single PowerShell script that spins up a throwaway PostgreSQL Docker
+  container, runs the EF tooling, and drops the container afterwards. Use whenever a
+  domain/entity change needs a schema migration. Triggers: "add a migration", "generate
+  an EF migration", "create a migration for X", "I changed an entity, make the migration",
+  "revert/remove the last migration", "undo that migration".
+---
+
+# Generate migration — one-shot EF Core migrations via a throwaway Postgres container
+
+Backend migrations live in `src/backend/Infrastructure/Data/Migrations` for `DanceDbContext`.
+The design-time factory (`Infrastructure/Data/DesignTimeContextFactory.cs`) is hardcoded to
+`localhost:5432` / db `dancedance`. This skill never hand-writes a migration and never
+requires you to manage a database by hand: each script **starts a disposable PostgreSQL
+container, runs the EF command, and removes the container** in one invocation.
+
+## When to use
+
+After (or as part of) any change to an entity under `Application/Domain/Entities/` or its EF
+configuration — a new entity, a new/renamed/removed column, an FK or index change. Generate
+the migration with the script rather than `dotnet ef` directly, so it is validated against a
+real database and the container lifecycle is handled for you.
+
+## Prerequisites
+
+- Docker Desktop running.
+- The **local stack must be stopped** first — it also binds port `5432` (`DC down` if it's
+  up; see the `local-stack` skill). The script fails fast with a clear message on a port clash.
+- `dotnet-ef` (the script attempts `dotnet tool restore`, then tells you to
+  `dotnet tool install --global dotnet-ef` if still missing).
+
+## Add a migration
+
+Make the entity / EF-config change first, then:
+
+```powershell
+.claude/skills/generate-migration/scripts/add-migration.ps1 -Name <PascalCaseName>
+```
+
+What it does, in order: start a throwaway postgres container → `dotnet ef migrations add`
+(into `Data/Migrations`) → apply it to the fresh DB to prove it applies cleanly →
+remove the container (always, even on failure). Pass `-NoApply` to skip the validation step
+and only generate the files.
+
+Name the migration after the change, e.g. `-Name AddCompetitions`. Review the generated
+`*.cs` + `*.Designer.cs` and the updated `DanceDbContextModelSnapshot.cs` before committing.
+
+## Revert / remove the most recent migration
+
+To undo a migration you just generated but have not shipped:
+
+```powershell
+.claude/skills/generate-migration/scripts/remove-migration.ps1
+```
+
+It spins up the container, runs `dotnet ef migrations remove --force` (deletes the last
+migration's files and reverts the model snapshot), and drops the container. Re-run
+`add-migration.ps1` after fixing the model to regenerate.
+
+## Notes
+
+- Both scripts resolve the `Infrastructure` project relative to the repo root, so they work
+  from any working directory (including a git worktree).
+- The container is named `tbdance-ef-migration` and is fully disposable — no data persists
+  between runs; it exists only so EF can build and validate against a real PostgreSQL.

--- a/.claude/skills/generate-migration/scripts/_common.ps1
+++ b/.claude/skills/generate-migration/scripts/_common.ps1
@@ -1,0 +1,82 @@
+# Shared helpers for the generate-migration scripts.
+# Dot-sourced by add-migration.ps1 and remove-migration.ps1 — not meant to be run directly.
+#
+# A throwaway PostgreSQL container is used so EF can validate the migration against a real
+# database. Its credentials/port match the hardcoded design-time connection string in
+# src/backend/Infrastructure/Data/DesignTimeContextFactory.cs
+# (Server=localhost;Port=5432;Userid=postgres;Password=...;Database=dancedance).
+
+$script:MigrationDbContainer = 'tbdance-ef-migration'
+$script:MigrationDbPassword  = 'rgFraWIuyxONqWCQ71wh'
+$script:MigrationDbName      = 'dancedance'
+$script:MigrationDbPort      = 5432
+$script:PostgresImage        = 'postgres'
+
+function Get-RepoRoot {
+    # scripts -> generate-migration -> skills -> .claude -> repo root
+    return (Resolve-Path (Join-Path $PSScriptRoot '..\..\..\..')).Path
+}
+
+function Get-InfrastructureProject {
+    $proj = Join-Path (Get-RepoRoot) 'src\backend\Infrastructure'
+    if (-not (Test-Path $proj)) {
+        throw "Infrastructure project not found at $proj"
+    }
+    return $proj
+}
+
+function Assert-Docker {
+    if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+        throw "docker not found on PATH. Install Docker Desktop and ensure it is running."
+    }
+    docker info *> $null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Docker is not running. Start Docker Desktop and retry."
+    }
+}
+
+function Assert-DotnetEf {
+    dotnet ef --version *> $null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "dotnet-ef not available; attempting 'dotnet tool restore'..." -ForegroundColor Yellow
+        dotnet tool restore *> $null
+        dotnet ef --version *> $null
+        if ($LASTEXITCODE -ne 0) {
+            throw "dotnet-ef is not installed. Run: dotnet tool install --global dotnet-ef"
+        }
+    }
+}
+
+function Start-MigrationDb {
+    Assert-Docker
+
+    # Remove any stale container left over from a previously interrupted run.
+    docker rm -f $script:MigrationDbContainer *> $null
+
+    Write-Host "Starting throwaway PostgreSQL container '$script:MigrationDbContainer' on port $script:MigrationDbPort..." -ForegroundColor Cyan
+    docker run -d --name $script:MigrationDbContainer `
+        -e "POSTGRES_PASSWORD=$script:MigrationDbPassword" `
+        -e "POSTGRES_DB=$script:MigrationDbName" `
+        -p "$($script:MigrationDbPort):5432" `
+        $script:PostgresImage | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to start the postgres container. Port $script:MigrationDbPort may already be in use - stop the local stack (it also binds 5432) and retry."
+    }
+
+    # Wait until the server accepts connections.
+    $deadline = (Get-Date).AddSeconds(60)
+    while ((Get-Date) -lt $deadline) {
+        docker exec $script:MigrationDbContainer pg_isready -U postgres -d $script:MigrationDbName *> $null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "PostgreSQL is ready." -ForegroundColor Green
+            return
+        }
+        Start-Sleep -Milliseconds 800
+    }
+    throw "PostgreSQL container did not become ready within 60s."
+}
+
+function Stop-MigrationDb {
+    Write-Host "Removing container '$script:MigrationDbContainer'..." -ForegroundColor Cyan
+    docker rm -f $script:MigrationDbContainer *> $null
+}

--- a/.claude/skills/generate-migration/scripts/add-migration.ps1
+++ b/.claude/skills/generate-migration/scripts/add-migration.ps1
@@ -1,0 +1,62 @@
+<#
+.SYNOPSIS
+    Generate a new EF Core migration for DanceDbContext against a throwaway PostgreSQL container.
+
+.DESCRIPTION
+    One command does everything: starts a disposable postgres container (matching the
+    design-time connection string), runs `dotnet ef migrations add`, applies it to the
+    fresh database to prove it applies cleanly, then removes the container - always, even
+    if a step fails.
+
+    Migrations land in src/backend/Infrastructure/Data/Migrations (the project's existing
+    non-default output dir). The local stack must NOT be running, because it also binds
+    port 5432.
+
+.PARAMETER Name
+    The migration name in PascalCase, e.g. AddCompetitions.
+
+.PARAMETER NoApply
+    Generate the migration only; skip applying it to the throwaway database.
+
+.EXAMPLE
+    ./add-migration.ps1 -Name AddCompetitions
+
+.EXAMPLE
+    ./add-migration.ps1 AddCompetitions -NoApply
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string]$Name,
+    [switch]$NoApply
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot '_common.ps1')
+
+$infra = Get-InfrastructureProject
+Assert-DotnetEf
+
+try {
+    Start-MigrationDb
+
+    Write-Host "Adding migration '$Name'..." -ForegroundColor Cyan
+    dotnet ef migrations add $Name `
+        --project $infra `
+        --startup-project $infra `
+        --output-dir Data/Migrations
+    if ($LASTEXITCODE -ne 0) { throw "dotnet ef migrations add failed." }
+
+    if (-not $NoApply) {
+        Write-Host "Applying migration to the throwaway DB to validate it..." -ForegroundColor Cyan
+        dotnet ef database update --project $infra --startup-project $infra
+        if ($LASTEXITCODE -ne 0) {
+            throw "dotnet ef database update failed - the migration does not apply cleanly. Review it (or run remove-migration.ps1)."
+        }
+    }
+
+    Write-Host "Migration '$Name' generated under src/backend/Infrastructure/Data/Migrations." -ForegroundColor Green
+}
+finally {
+    Stop-MigrationDb
+}

--- a/.claude/skills/generate-migration/scripts/remove-migration.ps1
+++ b/.claude/skills/generate-migration/scripts/remove-migration.ps1
@@ -1,0 +1,38 @@
+<#
+.SYNOPSIS
+    Revert (remove) the most recent EF Core migration for DanceDbContext.
+
+.DESCRIPTION
+    Starts a disposable postgres container, runs `dotnet ef migrations remove --force`
+    (deletes the last migration's files and reverts the model snapshot), then removes the
+    container — always, even on failure. Use this to undo a migration you just generated
+    with add-migration.ps1 but have not yet committed/shipped.
+
+    The local stack must NOT be running, because it also binds port 5432.
+
+.EXAMPLE
+    ./remove-migration.ps1
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot '_common.ps1')
+
+$infra = Get-InfrastructureProject
+Assert-DotnetEf
+
+try {
+    Start-MigrationDb
+
+    Write-Host "Removing the most recent migration..." -ForegroundColor Cyan
+    dotnet ef migrations remove --force `
+        --project $infra `
+        --startup-project $infra
+    if ($LASTEXITCODE -ne 0) { throw "dotnet ef migrations remove failed." }
+
+    Write-Host "Most recent migration removed; model snapshot reverted." -ForegroundColor Green
+}
+finally {
+    Stop-MigrationDb
+}


### PR DESCRIPTION
## What

- **New `generate-migration` skill** (`.claude/skills/generate-migration/`) — creates or reverts an EF Core migration for `DanceDbContext` through a single PowerShell script that handles the whole lifecycle: spin up a throwaway PostgreSQL container, run the EF tooling, drop the container.
  - `scripts/add-migration.ps1 -Name <PascalCase>` — start container → `dotnet ef migrations add` (into `Data/Migrations`) → apply to the fresh DB to validate it applies cleanly → drop container (in `finally`, always). `-NoApply` skips validation.
  - `scripts/remove-migration.ps1` — start container → `dotnet ef migrations remove --force` → drop container.
  - `scripts/_common.ps1` — shared container lifecycle + guards (Docker present/running, `dotnet-ef` available with `tool restore` fallback, `pg_isready` readiness wait). Container credentials/port/db match the hardcoded `DesignTimeContextFactory` (`localhost:5432`, `dancedance`).
- **`feature-planning` skill updated**:
  - Each implementation subtask now covers writing the tests for its own slice (when testable in isolation); no separate `Tests` subtask. The `Local setup / verification` subtask stays.
  - Schema-changing slices are directed to generate their migration via the `generate-migration` skill rather than hand-writing it.

## Why

- Generating migrations by hand is error-prone; this makes it a one-command, validated, self-cleaning operation.
- Folding tests into each implementation subtask keeps test coverage attached to the code it exercises and produces smaller, self-contained, independently reviewable PRs.

## Notes for reviewers

- Skill/tooling changes only — no application or backend code is touched.
- The migration scripts require Docker running and the local stack **stopped** (both bind port 5432); the script fails fast with a clear message on a port clash.
- `.ps1` files are kept ASCII so they parse under Windows PowerShell 5.1 (which reads BOM-less files as ANSI); all three parse cleanly and the repo-root resolution was verified against the real `Infrastructure` project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)