### PR TITLE
Carry the current URL through login so shared links survive sign-in

### DIFF
--- a/src/my-dance.web/src/app/core/auth/auth.service.spec.ts
+++ b/src/my-dance.web/src/app/core/auth/auth.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
 import { OidcSecurityService } from 'angular-auth-oidc-client';
 import { BehaviorSubject, of } from 'rxjs';
 
@@ -25,12 +26,18 @@ function createOidcMock() {
 describe('AuthService', () => {
   let service: AuthService;
   let oidc: ReturnType<typeof createOidcMock>;
+  let router: { url: string };
 
   beforeEach(() => {
     sessionStorage.clear();
     oidc = createOidcMock();
+    router = { url: '/' };
     TestBed.configureTestingModule({
-      providers: [AuthService, { provide: OidcSecurityService, useValue: oidc }],
+      providers: [
+        AuthService,
+        { provide: OidcSecurityService, useValue: oidc },
+        { provide: Router, useValue: router },
+      ],
     });
     service = TestBed.inject(AuthService);
   });
@@ -64,8 +71,20 @@ describe('AuthService', () => {
       expect(oidc.authorize).toHaveBeenCalledTimes(1);
     });
 
-    it('login() without a return url does not write session storage', () => {
+    it('login() without a return url stores the current url so the user returns to it', () => {
+      router.url = '/shared/abc123';
+
       service.login();
+
+      expect(sessionStorage.getItem(RETURN_URL_KEY)).toBe('/shared/abc123');
+      expect(oidc.authorize).toHaveBeenCalledTimes(1);
+    });
+
+    it('login() from the home route does not write session storage', () => {
+      router.url = '/';
+
+      service.login();
+
       expect(sessionStorage.getItem(RETURN_URL_KEY)).toBeNull();
       expect(oidc.authorize).toHaveBeenCalledTimes(1);
     });

--- a/src/my-dance.web/src/app/core/auth/auth.service.ts
+++ b/src/my-dance.web/src/app/core/auth/auth.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, computed, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
+import { Router } from '@angular/router';
 import { OidcSecurityService } from 'angular-auth-oidc-client';
 import { Observable } from 'rxjs';
 
@@ -13,6 +14,7 @@ const RETURN_URL_KEY = 'auth.returnUrl';
 @Injectable({ providedIn: 'root' })
 export class AuthService {
   private readonly oidc = inject(OidcSecurityService);
+  private readonly router = inject(Router);
 
   private readonly authState = toSignal(this.oidc.isAuthenticated$, {
     initialValue: { isAuthenticated: false, allConfigsAuthenticated: [] },
@@ -29,10 +31,17 @@ export class AuthService {
     return this.oidc.checkAuth();
   }
 
-  /** Starts the OIDC login flow, remembering where to return afterwards. */
+  /**
+   * Starts the OIDC login flow, remembering where to return afterwards.
+   *
+   * Defaults to the URL the user is currently on so that signing in from, say,
+   * a shared-link page brings them back to it (the post-login callback would
+   * otherwise drop them on the home page). The home route is not worth storing.
+   */
   login(returnUrl?: string): void {
-    if (returnUrl) {
-      sessionStorage.setItem(RETURN_URL_KEY, returnUrl);
+    const target = returnUrl ?? this.router.url;
+    if (target && target !== '/') {
+      sessionStorage.setItem(RETURN_URL_KEY, target);
     }
     this.oidc.authorize();
   }


### PR DESCRIPTION
## What

`AuthService.login()` now defaults the post-login return URL to the URL the user is currently on when no explicit return URL is passed.

## Why

The `/shared/:linkId` route is **public**, so visiting a shared link does not itself trigger an auth redirect. But when a user on that page clicks **Sign in** (e.g. to comment as themselves), the navbar/landing buttons called `auth.login()` with **no return URL**. The return-URL plumbing (sessionStorage → consumed in `callback.ts`) was only ever fed by `authGuard`, so the post-login callback fell back to `/` and the shared-link path was lost.

## How

- `auth.service.ts` — inject `Router`; `login(returnUrl?)` now falls back to `this.router.url` when no argument is given. The home route (`/`) is still skipped since there is nothing useful to return to.
- No changes needed at the call sites (`navbar`, `landing`) — they flow through the updated `login()`. Explicit callers (`authGuard` passing `state.url`, callback `retry()`) are unchanged since an explicit `returnUrl` still takes precedence.

## Tests

- `auth.service.spec.ts` — provides a `Router` stub; replaced the "no return url" case with one asserting the current URL is captured, plus a case confirming `/` is not stored.
- Full web suite green: 316 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
