### PR TITLE
DD-10: show recording thumbnail as video poster on the player page

### DIFF
--- a/src/my-dance.web/src/app/features/videos/video-player.html
+++ b/src/my-dance.web/src/app/features/videos/video-player.html
@@ -66,12 +66,13 @@
 
   @if (streamUrl(); as src) {
     <video
-      class="is-block"
-      style="width: 100%; max-height: 70vh; background: #000"
+      class="is-block video-player__video"
+      style="width: 100%; max-height: 70vh"
       controls
       controlsList="nodownload"
       preload="metadata"
       [src]="src"
+      [attr.poster]="posterUrl()"
       [attr.aria-label]="'Recording: ' + video.name"
       (contextmenu)="$event.preventDefault()"
     >

--- a/src/my-dance.web/src/app/features/videos/video-player.spec.ts
+++ b/src/my-dance.web/src/app/features/videos/video-player.spec.ts
@@ -90,6 +90,22 @@ describe('VideoPlayer', () => {
     expect(video.getAttribute('controlsList')).toBe('nodownload');
   });
 
+  it('sets the video poster from the recording thumbnail', () => {
+    const { fixture } = createFixture({
+      video: { ...CONVERTED, thumbnailUrl: 'https://azurite/thumbnails/abc?sv=2024' },
+    });
+    const video = fixture.nativeElement.querySelector('video') as HTMLVideoElement;
+
+    expect(video.getAttribute('poster')).toBe('https://azurite/thumbnails/abc?sv=2024');
+  });
+
+  it('omits the poster attribute when the recording has no thumbnail', () => {
+    const { fixture } = createFixture({});
+    const video = fixture.nativeElement.querySelector('video') as HTMLVideoElement;
+
+    expect(video.getAttribute('poster')).toBeNull();
+  });
+
   it('does not expose a stream url for an unconverted recording', () => {
     const { component, videos } = createFixture({
       video: { videoId: 'vid1', blobId: 'blob1', converted: false },

--- a/src/my-dance.web/src/app/features/videos/video-player.ts
+++ b/src/my-dance.web/src/app/features/videos/video-player.ts
@@ -34,6 +34,15 @@ const SIBLINGS_PAGE_SIZE = 100;
   imports: [LongDatePipe, CommentsSection, VideoList],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './video-player.html',
+  styles: `
+    /* Same placeholder fallback as video cards: visible behind the poster/frame
+       until either loads, so there's no black flash before metadata resolves. */
+    .video-player__video {
+      background:
+        radial-gradient(circle at 82% 18%, rgba(255, 255, 255, 0.34), transparent 24%),
+        linear-gradient(135deg, #20314f 0%, #2f6f73 56%, #f0b35a 100%);
+    }
+  `,
 })
 export class VideoPlayer {
   /** Bound from the route `:blobId` param via withComponentInputBinding(). */
@@ -64,6 +73,7 @@ export class VideoPlayer {
   private readonly videoId = signal<string | null>(null);
 
   readonly siblings = signal<readonly VideoInformation[]>([]);
+  readonly posterUrl = computed(() => this.info()?.thumbnailUrl ?? null);
 
   readonly editingName = signal(false);
   readonly nameDraft = signal('');


### PR DESCRIPTION
## Summary
- Binds `VideoInformation.thumbnailUrl` to the `<video poster>` attribute on the video detail/player page, so the recording's thumbnail shows before playback starts.
- Falls back to the same gradient placeholder used on video cards when there's no thumbnail yet (no black flash), via a `video-player__video` background style mirroring `video-card.ts`.

Closes DD-10 (https://tb.youtrack.cloud/issue/DD-10). The plumbing (`ThumbnailBlobId` + `VideosService.thumbnailUrl()`) already existed from the thumbnails epic (DD-2 through DD-9); this was the one remaining follow-up.

## Test plan
- [x] `npm run test:ci` — 318/318 unit tests pass, including 2 new tests covering poster-set and poster-omitted cases.
- [x] `npm run build` — clean build.
- [x] Verified live in the local stack: logged in, opened a recording with a thumbnail, confirmed the poster image renders before playback (screenshot captured during review).
- [x] Confirmed via `preview_inspect` that the gradient placeholder CSS (`background-image`) matches the video-card fallback exactly.
- [ ] Manual cross-browser check in Firefox (per the issue's acceptance criteria) — not performed in this session, only Chromium-based preview was used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)