### PR TITLE
Refactor migration tests to use per-class connection strings

### DIFF
--- a/src/tests/TB.DanceDance.Tests/BaseTestClass.cs
+++ b/src/tests/TB.DanceDance.Tests/BaseTestClass.cs
@@ -5,13 +5,17 @@ namespace TB.DanceDance.Tests;
 
 public abstract class BaseTestClass : IAsyncLifetime
 {
+    private readonly DanceDbFixture dbContextFixture;
     protected readonly DanceDbContext SeedDbContext;
     private readonly DanceDbContext runtimeDbContext;
+    private readonly string ConnectionString;
     
     protected BaseTestClass(DanceDbFixture dbContextFixture)
     {
-        SeedDbContext = dbContextFixture.DbContextFactory();
-        runtimeDbContext = dbContextFixture.DbContextFactory();
+        this.ConnectionString = dbContextFixture.GetConnectionStringForThisClassSet(TestContext.Current);
+        this.dbContextFixture = dbContextFixture;
+        SeedDbContext = dbContextFixture.DbContextFactory(ConnectionString);
+        runtimeDbContext = dbContextFixture.DbContextFactory(ConnectionString);
     }
 
     protected abstract ValueTask Initialize(DanceDbContext runtimeDbContext);
@@ -28,8 +32,11 @@ public abstract class BaseTestClass : IAsyncLifetime
         await SeedDbContext.DisposeAsync();
     }
 
-    public ValueTask InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return Initialize(runtimeDbContext);
+        var dbContext = dbContextFixture.DbContextFactory(ConnectionString);
+        await dbContext.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+        
+        await Initialize(runtimeDbContext);
     }
 }

--- a/src/tests/TB.DanceDance.Tests/MigrationTests/DanceDbMigrationTests.cs
+++ b/src/tests/TB.DanceDance.Tests/MigrationTests/DanceDbMigrationTests.cs
@@ -6,7 +6,13 @@ namespace TB.DanceDance.Tests.MigrationTests;
 [TestCaseOrderer(typeof(PriorityOrderer))]
 public class DanceDbMigrationTests : IAsyncLifetime
 {
-    private readonly DanceDbFixture dbFixture = new DanceDbFixture();
+    private readonly DanceDbFixture dbFixture = new();
+    private readonly string connectionString;
+
+    public DanceDbMigrationTests()
+    {
+        connectionString = dbFixture.GetConnectionStringForThisClassSet(TestContext.Current);
+    }
     
     public async ValueTask DisposeAsync()
     {
@@ -21,12 +27,12 @@ public class DanceDbMigrationTests : IAsyncLifetime
     [Fact, TestPriority(2)]
     public async Task UpMigrationsCanRun()
     {
-        await dbFixture.DbContextFactory(dbFixture.DefaultConnectionString).Database.MigrateAsync(TestContext.Current.CancellationToken);
+        await dbFixture.DbContextFactory(connectionString).Database.MigrateAsync(TestContext.Current.CancellationToken);
     }
     
     [Fact, TestPriority(1)]
     public async Task DownMigrationsCanRun()
     {
-        await dbFixture.DbContextFactory(dbFixture.DefaultConnectionString).Database.MigrateAsync("20230617222723_Initial", TestContext.Current.CancellationToken);
+        await dbFixture.DbContextFactory(connectionString).Database.MigrateAsync("20230617222723_Initial", TestContext.Current.CancellationToken);
     }
 }

--- a/src/tests/TB.DanceDance.Tests/MigrationTests/DanceDbMigrationTests.cs
+++ b/src/tests/TB.DanceDance.Tests/MigrationTests/DanceDbMigrationTests.cs
@@ -7,12 +7,7 @@ namespace TB.DanceDance.Tests.MigrationTests;
 public class DanceDbMigrationTests : IAsyncLifetime
 {
     private readonly DanceDbFixture dbFixture = new();
-    private readonly string connectionString;
-
-    public DanceDbMigrationTests()
-    {
-        connectionString = dbFixture.GetConnectionStringForThisClassSet(TestContext.Current);
-    }
+    private string connectionString = string.Empty;
     
     public async ValueTask DisposeAsync()
     {
@@ -22,15 +17,16 @@ public class DanceDbMigrationTests : IAsyncLifetime
     public async ValueTask InitializeAsync()
     {
         await dbFixture.InitializeAsync();
+        connectionString = dbFixture.GetConnectionStringForThisClassSet(TestContext.Current);
     }
 
-    [Fact, TestPriority(2)]
+    [Fact, TestPriority(1)]
     public async Task UpMigrationsCanRun()
     {
         await dbFixture.DbContextFactory(connectionString).Database.MigrateAsync(TestContext.Current.CancellationToken);
     }
     
-    [Fact, TestPriority(1)]
+    [Fact, TestPriority(2)]
     public async Task DownMigrationsCanRun()
     {
         await dbFixture.DbContextFactory(connectionString).Database.MigrateAsync("20230617222723_Initial", TestContext.Current.CancellationToken);

--- a/src/tests/TB.DanceDance.Tests/MigrationTests/DanceDbMigrationTests.cs
+++ b/src/tests/TB.DanceDance.Tests/MigrationTests/DanceDbMigrationTests.cs
@@ -15,19 +15,18 @@ public class DanceDbMigrationTests : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        dbFixture.InitializeDbAtStart = false;
         await dbFixture.InitializeAsync();
     }
 
     [Fact, TestPriority(2)]
     public async Task UpMigrationsCanRun()
     {
-        await dbFixture.DbContextFactory().Database.MigrateAsync(TestContext.Current.CancellationToken);
+        await dbFixture.DbContextFactory(dbFixture.DefaultConnectionString).Database.MigrateAsync(TestContext.Current.CancellationToken);
     }
     
     [Fact, TestPriority(1)]
     public async Task DownMigrationsCanRun()
     {
-        await dbFixture.DbContextFactory().Database.MigrateAsync("20230617222723_Initial", TestContext.Current.CancellationToken);
+        await dbFixture.DbContextFactory(dbFixture.DefaultConnectionString).Database.MigrateAsync("20230617222723_Initial", TestContext.Current.CancellationToken);
     }
 }

--- a/src/tests/TB.DanceDance.Tests/TestsFixture/DanceDbFixture.cs
+++ b/src/tests/TB.DanceDance.Tests/TestsFixture/DanceDbFixture.cs
@@ -12,17 +12,17 @@ public class DanceDbFixture() : IAsyncLifetime
 
     private readonly PostgreSqlContainer container = new PostgreSqlBuilder(PostgresImage)
         .Build();
-
-    public bool InitializeDbAtStart { get; set; } = true;
     
-    public DanceDbContext DbContextFactory()
+    public DanceDbContext DbContextFactory(string connectionString)
     {
         var optionsBuilder = new DbContextOptionsBuilder<DanceDbContext>()
-            .UseNpgsql(container.GetConnectionString());
+            .UseNpgsql(connectionString);
         
         DanceDbContext danceDbContext = new DanceDbContext(optionsBuilder.Options);
         return danceDbContext;
     }
+    
+    public string DefaultConnectionString => container.GetConnectionString();
     
     public ValueTask DisposeAsync()
     {
@@ -32,7 +32,16 @@ public class DanceDbFixture() : IAsyncLifetime
     public async ValueTask InitializeAsync()
     {
         await container.StartAsync();
-        if (InitializeDbAtStart)
-            await DbContextFactory().Database.EnsureCreatedAsync();
+    }
+    
+    public string GetConnectionStringForThisClassSet(ITestContext testContext)
+    {
+        var name = testContext.TestClass?.TestClassSimpleName;
+        var connectionString = container.GetConnectionString();
+        
+        if (name is null)
+            return connectionString;
+
+        return connectionString.Replace("Database=postgres", $"Database={name}");
     }
 }


### PR DESCRIPTION
```
### Description

This pull request refactors the migration tests to support per-class connection strings. The following changes were made:

- Updated `DanceDbMigrationTests` to utilize class-specific connection strings for improved test isolation.
- Modified `DanceDbFixture` to enable configurable connection strings for `DbContextFactory`.
- Ensured `BaseTestClass` initializes databases with class-specific settings.
- Migration tests now use `DefaultConnectionString` explicitly.


```