### PR TITLE
Publish frontend Docker image from release workflow

### DIFF
--- a/.github/workflows/docker-publish-release.yml
+++ b/.github/workflows/docker-publish-release.yml
@@ -12,6 +12,7 @@ env:
   apiDockerHubRepo: possibility022/tbdancedanceapi
   converterDockerHubRepo: possibility022/tbdancedanceconverter
   authserverDockerHubRepo: possibility022/tbdancedanceauthserver
+  frontendDockerHubRepo: possibility022/tbdancedanceweb
 
 jobs:
   build-and-push-api-docker-image:
@@ -114,6 +115,41 @@ jobs:
         with:
           context: src
           file: src/authserver/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+
+  build-and-push-frontend-docker-image:
+    name: Build and Push Frontend Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v5
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: |
+            ${{ env.frontendDockerHubRepo }}
+          tags: |
+            type=ref,event=pr,prefix=alpha-pr-,suffix=-{{sha}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push Docker images
+        id: push
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: src/my-dance.web
+          file: src/my-dance.web/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## What

Adds a fourth job, `build-and-push-frontend-docker-image`, to `.github/workflows/docker-publish-release.yml` that builds and pushes the Angular frontend (`src/my-dance.web`) to Docker Hub as `possibility022/tbdancedanceweb`.

## Why

The release workflow already publishes the API, converter daemon, and auth server images, but the frontend was never published despite having a production Dockerfile and being run as the `frontendspa` service locally. This ships the frontend image alongside the others with the same versioning scheme.

## Details

- New `frontendDockerHubRepo: possibility022/tbdancedanceweb` env var.
- New job mirrors the existing three exactly — same pinned action SHAs, same tag patterns (`alpha-pr-*` on PRs, `{version}` / `{major}.{minor}` on release), and the existing `DOCKER_USERNAME` / `DOCKER_PASSWORD` secrets.
- Build context is `src/my-dance.web` (not `./src` like the backend jobs) to match the frontend Dockerfile's relative `COPY package*.json ./` / `COPY . .` paths and the `local_environment.dockercompose.yaml` `frontendspa` build config.

## Reviewer notes

- No new env vars or secrets are required. The Dockerfile has no build-args; runtime config (`API_BASE_URL`, `AUTH_URL`, `REDIRECT_URI`) is generated at container startup by `docker-entrypoint.sh`, so the image is environment-agnostic.
- One out-of-repo prerequisite: the `possibility022/tbdancedanceweb` repo must exist on Docker Hub (or be auto-created on first push by the publishing account).

🤖 Generated with [Claude Code](https://claude.com/claude-code)